### PR TITLE
Auto releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,31 @@
+before:
+  hooks:
+    - go mod tidy
+builds:
+  -
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - freebsd
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm
+      - arm64
+archives:
+- replacements:
+    darwin: macOS
+    linux: linux
+    386: x86
+    amd64: amd64
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: go
+
+go:
+  - "1.13"
+  - tip
+
+script:
+  - go build .
+
+# calls goreleaser
+deploy:
+- provider: script
+  skip_cleanup: true
+  script: curl -sL https://git.io/goreleaser | bash
+  on:
+    tags: true
+    condition: $TRAVIS_OS_NAME = linux

--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# Gitmux
+
+Gitmux shows Git in your tmux status bar.
+
+## Installation
+
+### Pre-compiled binaries for all supported platforms
+
+Download the latest binary release for your platform and add it to your `$PATH`.
+
+### Build from source
+
+Install the latest [Go version](https://golang.org/dl/) and then run:
+
+```bash
+go get github.com/arl/gitmux
+```
+
+## Usage
+
+Add this line to your  `.tmux.conf`
+
+```
+# Show Git working tree status
+set -g status-right '#(gitmux -q -fmt tmux #{pane_current_path})'
+```
+
+## Contributing
+Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
+
+
+## License
+[MIT](./LICENSE)

--- a/cli.go
+++ b/cli.go
@@ -18,11 +18,12 @@ func check(err error, quiet bool) {
 	}
 }
 
-const version = "0.1"
-const usage = `gitstatus ` + version + `
-Usage: gitstatus [options] [dir]
+var version = "<<development version>>"
 
-gitstatus prints the status of a Git working tree.
+var usage = `gitmux ` + version + `
+Usage: gitmux [options] [dir]
+
+gitmux prints the status of a Git working tree.
 If directory is not given, it default to the working directory.  
 
 Options:
@@ -30,8 +31,9 @@ Options:
   -fmt            output format, defaults to json.
       json        prints status as a JSON object.
       tmux        prints status as a tmux format string.
-  -cfg cfgfile    gitstatus output configuration file.
+  -cfg cfgfile    use cfgfile when printing git status.
   -printcfg       prints default configuration file.
+  -V		  prints gitmux version and exits.
 `
 
 var defaultCfg = Config{Tmux: tmux.DefaultCfg}
@@ -41,6 +43,7 @@ func parseOptions() (dir string, format string, quiet bool, cfg Config) {
 	cfgOpt := flag.String("cfg", "", "")
 	printCfgOpt := flag.Bool("printcfg", false, "")
 	quietOpt := flag.Bool("q", false, "")
+	versionOpt := flag.Bool("V", false, "")
 	flag.Usage = func() {
 		fmt.Println(usage)
 	}
@@ -50,6 +53,10 @@ func parseOptions() (dir string, format string, quiet bool, cfg Config) {
 		dir = flag.Arg(0)
 	}
 	cfg = defaultCfg
+	if *versionOpt {
+		fmt.Println(version)
+		os.Exit(0)
+	}
 	if *printCfgOpt {
 		enc := yaml.NewEncoder(os.Stdout)
 		check(enc.Encode(&defaultCfg), *quietOpt)


### PR DESCRIPTION
On travis-ci, test that we can build
Then add goreleaser hook on tagged commits so that binary releases for all supported platforms are pushed to gh releases