### PR TITLE
Issue 9/add git no optional lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
-# GiTmux [![Build Status](https://travis-ci.com/arl/gitmux.svg?branch=master)](https://travis-ci.com/arl/gitmux) [![Go Report Card](https://goreportcard.com/badge/github.com/arl/gitmux)](https://goreportcard.com/report/github.com/arl/gitmux)
+# Gitmux [![Build Status](https://travis-ci.com/arl/gitmux.svg?branch=master)](https://travis-ci.com/arl/gitmux) [![Go Report Card](https://goreportcard.com/badge/github.com/arl/gitmux)](https://goreportcard.com/report/github.com/arl/gitmux)
 
-![GiTmux in action](https://raw.githubusercontent.com/arl/gitmux/readme-images/demo-small.gif)
+![Gitmux in action](https://raw.githubusercontent.com/arl/gitmux/readme-images/demo-small.gif)
 
-**GiTmux** shows **Git** status in your **Tmux** status bar.
+**Gitmux** shows **Git** status in your **Tmux** status bar.
 
 ## Description
 
-If the working directory is managed by Git, **GiTmux** will show **Git status**
+If the working directory is managed by Git, **Gitmux** will show **Git status**
 information in a **minimal** and useful manner, right in Tmux status bar.  
-GiTmux gets _out of your way_ when it has nothing to say (out of a Git
+Gitmux gets _out of your way_ when it has nothing to say (out of a Git
 working tree).
 
-**GiTmux** comes with sensible defaults though you can customize everything: colors, symbols, which information to show.
+**Gitmux** comes with sensible defaults though you can customize everything: colors, symbols, which information to show.
 
 **To sum things up**:
  - you use **Tmux**
  - you're tired to type `git status`, or you're just _lazy_, like me
  - you want to keep your prompt tidy
 
-then **GiTmux** is made for you!
+then **Gitmux** is made for you!
 
 ## Installation
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/arl/gitmux
 go 1.10
 
 require (
-	github.com/arl/gitstatus v0.4.1
+	github.com/arl/gitstatus v0.4.2
 	github.com/stretchr/testify v1.3.0
 	gopkg.in/yaml.v2 v2.2.4
 )

--- a/go.sum
+++ b/go.sum
@@ -1,13 +1,7 @@
-github.com/arl/gitstatus v0.4.1 h1:BDMFkvy+fet1nnxvkr4hTIc2Oy5FVcB6oIYRLY0eQp8=
-github.com/arl/gitstatus v0.4.1/go.mod h1:pEiL+vLLz99X0m5G4MySAt4o0fQw2yUbFeq2s7sMUzY=
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/arl/gitstatus v0.4.2/go.mod h1:pEiL+vLLz99X0m5G4MySAt4o0fQw2yUbFeq2s7sMUzY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
    Bump gitstatus
    
    By bumping gitstatus to v0.4.2 we're now calling git with
    GIT_OPTIONAL_LOCKS set to 0, ensuring gitstatus does not lock the
    working tree for its operations, effectively giving higher
    priority to user-initiated operations. This is useful when gitmux
    is run in the background.
    
    Fixes #9
