### PR TITLE
Sensible defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Gitmux [![Build Status](https://travis-ci.com/arl/gitmux.svg?branch=master)](https://travis-ci.com/arl/gitmux) [![Go Report Card](https://goreportcard.com/badge/github.com/arl/gitmux)](https://goreportcard.com/report/github.com/arl/gitmux)
 
+
 ## **Gitmux** shows **Git** status in your **Tmux** status bar.
 
 ![Gitmux in action](https://raw.githubusercontent.com/arl/gitmux/readme-images/demo-small.gif)
+
 
 ## Description
 
@@ -24,6 +26,7 @@ And generally there's always a lot of empty space left in tmux status bar.
 
 **Gitmux** might be just for you!
 
+
 ## Installation
 
 * **Install a binary release for your platform** (preferred and simplest way) 
@@ -42,11 +45,43 @@ go get -u github.com/arl/gitmux
 
 ## Usage
 
-Simply add this line to your  `.tmux.conf`
+Simply add this line to your  `.tmux.conf`:
 
 ```
 # Show Git working tree status
-set -g status-right '#(gitmux -q -fmt tmux #{pane_current_path})'
+set -g status-right '#(gitmux #{pane_current_path})'
+```
+
+
+## Customize status string
+
+Nothing simpler! First save `gitmux` config in a file:
+
+```
+gitmux -printcfg > .gitmux.conf
+```
+
+`gitmux` config is divided in 2 sections:
+ - symbols are unicode characters
+ - styles are tmux format strings (man tmux for reference)
+
+Modify it, then feed that config each time you run `gitmux`:
+
+```
+gitmux -cfg .gitmux.conf
+```
+
+## Troubleshooting
+
+If something goes wrong, please [file an issue](https://github.com/arl/gitmux/issues/new)
+and indicate your tmux and gitmux versions,  
+what you did, what you saw and what you expected yo see.  
+Also you can run `gitmux -dbg` for debugging output.
+
+```
+tmux -V
+gitmux -V
+gitmux -dbg
 ```
 
 ## Contributing

--- a/format/json/formater.go
+++ b/format/json/formater.go
@@ -15,8 +15,10 @@ type Formater struct{}
 func (Formater) Format(w io.Writer, st *gitstatus.Status) error {
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", " ")
+
 	if err := enc.Encode(st); err != nil {
 		return fmt.Errorf("can't format status to json: %v", err)
 	}
+
 	return nil
 }

--- a/format/tmux/formater.go
+++ b/format/tmux/formater.go
@@ -98,6 +98,7 @@ fileCounts:
 	f.flags()
 
 	_, err := f.b.WriteTo(w)
+
 	return err
 }
 
@@ -149,11 +150,13 @@ func (f *Formater) currentRef() {
 
 func (f *Formater) divergence() {
 	f.clear()
+
 	pref := " "
 	if f.st.BehindCount != 0 {
 		fmt.Fprintf(&f.b, " %s%d", f.Symbols.Behind, f.st.BehindCount)
 		pref = ""
 	}
+
 	if f.st.AheadCount != 0 {
 		fmt.Fprintf(&f.b, "%s%s%d", pref, f.Symbols.Ahead, f.st.AheadCount)
 	}
@@ -162,6 +165,7 @@ func (f *Formater) divergence() {
 func (f *Formater) flags() {
 	f.clear()
 	f.b.WriteString(" - ")
+
 	if f.st.IsClean {
 		fmt.Fprintf(&f.b, "%s%s", f.Styles.Clean, f.Symbols.Clean)
 		return
@@ -173,21 +177,26 @@ func (f *Formater) flags() {
 		flags = append(flags,
 			fmt.Sprintf("%s%s%d", f.Styles.Staged, f.Symbols.Staged, f.st.NumStaged))
 	}
+
 	if f.st.NumConflicts != 0 {
 		flags = append(flags,
 			fmt.Sprintf("%s%s%d", f.Styles.Conflict, f.Symbols.Conflict, f.st.NumConflicts))
 	}
+
 	if f.st.NumModified != 0 {
 		flags = append(flags,
 			fmt.Sprintf("%s%s%d", f.Styles.Modified, f.Symbols.Modified, f.st.NumModified))
 	}
+
 	if f.st.NumStashed != 0 {
 		flags = append(flags,
 			fmt.Sprintf("%s%s%d", f.Styles.Stashed, f.Symbols.Stashed, f.st.NumStashed))
 	}
+
 	if f.st.NumUntracked != 0 {
 		flags = append(flags,
 			fmt.Sprintf("%s%s%d", f.Styles.Untracked, f.Symbols.Untracked, f.st.NumUntracked))
 	}
+
 	f.b.WriteString(strings.Join(flags, " "))
 }

--- a/gitmux.go
+++ b/gitmux.go
@@ -37,6 +37,8 @@ func parseOptions() (dir string, dbg bool, cfg Config) {
 	cfgOpt := flag.String("cfg", "", "")
 	printCfgOpt := flag.Bool("printcfg", false, "")
 	versionOpt := flag.Bool("V", false, "")
+	flag.Bool("q", true, "")   // unused, kept for retrocompatibility.
+	flag.String("fmt", "", "") // unused, kept for retrocompatibility.
 	flag.Usage = func() {
 		fmt.Println(usage)
 	}

--- a/main.go
+++ b/main.go
@@ -13,10 +13,8 @@ import (
 )
 
 func check(err error, dbg bool) {
-	if err != nil {
-		if dbg {
-			fmt.Println("error:", err)
-		}
+	if err != nil && dbg {
+		fmt.Fprintln(os.Stderr, "error:", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
## Change default options to more sensible ones
### Remove `-quiet` and `-fmt` option, replace them with `-dbg` since they
were only meant to be used if something went wrong.
### In debug mod, prints errors on stderr
### Improve README