### PR TITLE
Fix error check function

### DIFF
--- a/gitmux.go
+++ b/gitmux.go
@@ -88,10 +88,13 @@ func pushdir(dir string) (popdir func() error, err error) {
 }
 
 func check(err error, dbg bool) {
-	if err != nil && dbg {
-		fmt.Fprintln(os.Stderr, "error:", err)
-		os.Exit(1)
+	if err == nil {
+		return
 	}
+	if dbg {
+		fmt.Fprintln(os.Stderr, "error:", err)
+	}
+	os.Exit(1)
 }
 
 func main() {


### PR DESCRIPTION
When current directory was not a Git working tree, git command
were failing, as expected. But a recent commit made a change in
the error check function, and the program was not exit anymore in
the event of an error. Instead it was continuing with a bogus
gitstatus varriable, leading to panics. Unless running in -dbg
mode, those panic had no effect whatsoever and gitmux was usable
as before. It's just that the program was silently crashing
instead of silently terminating.