### PR TITLE
Update README with "#{pane_current_path}"

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Run `go get` to build and install `gitmux`:
 
 Add this line to your  `.tmux.conf`:
 
-    set -g status-right '#(gitmux #{pane_current_path})'
+    set -g status-right '#(gitmux "#{pane_current_path}")'
 
 
 ## Customizing


### PR DESCRIPTION
In README, add double quotes around `#{pane_current_path}` since without them no output is produced in OSX, at least in some configuration. Also it doesn't hurt to have those quotes in other configurations that do not require them.

Fixes #17