### PR TITLE
allow flexible display for output format of git status

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Modify the line in `.tmux.conf`, passing the path of the configuration file as a
 `gitmux` configuration is split into 3 sections:
  - symbols: they are just strings of unicode characters
  - styles: they are tmux format strings (`man tmux` for reference)
- - display: defines the layout in the form of a YAML array, seperators should be surrounded in single quotes example: `display: [branch, '..', remote, ' - ', flags]`
+ - display: defines the layout in the form of a YAML array, separators should be surrounded in single quotes example: `display: [branch, '..', remote, ' - ', flags]`
 
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -51,13 +51,13 @@ Add this line to your  `.tmux.conf`:
 
 ## Customizing
 
-`gitmux` output can be customized via a configuration file in YAML format.  
+`gitmux` output can be customized via a configuration file in YAML format.
 
 First, save the default configuration to a new file
 
     gitmux -printcfg > .gitmux.conf
 
-Open `.gitmux.conf` and modify it, replacing symbols and colors to suit your needs.  
+Open `.gitmux.conf` and modify it, replacing symbols and colors to suit your needs.
 Ensure the file is valid by adding the `-dbg` flag
 
     gitmux -dbg -cfg .gitmux.conf
@@ -66,11 +66,17 @@ Modify the line in `.tmux.conf`, passing the path of the configuration file as a
 
     gitmux -cfg .gitmux.conf
 
-
 `gitmux` configuration is split into 3 sections:
  - symbols: they are just strings of unicode characters
  - styles: they are tmux format strings (`man tmux` for reference)
- - display: defines the layout in the form of a YAML array, separators should be surrounded in single quotes example: `display: [branch, '..', remote, ' - ', flags]`
+ - layout: is the layout of git components & separators
+
+Example layouts:
+```
+layout: [branch, '..', remote, ' - ', flags]
+layout: [branch]
+layout: [flags, ' && ', branch]
+```
 
 
 ## Troubleshooting
@@ -79,6 +85,7 @@ Please report anything by [filing an issue](https://github.com/arl/gitmux/issues
 
 
 ## Contributing
+
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
 
 

--- a/README.md
+++ b/README.md
@@ -67,9 +67,10 @@ Modify the line in `.tmux.conf`, passing the path of the configuration file as a
     gitmux -cfg .gitmux.conf
 
 
-`gitmux` configuration is split into 2 sections:
+`gitmux` configuration is split into 3 sections:
  - symbols: they are just strings of unicode characters
  - styles: they are tmux format strings (`man tmux` for reference)
+ - display: defines the layout in the form of a YAML array, seperators should be surrounded in single quotes example: `display: [branch, '..', remote, ' - ', flags]`
 
 
 ## Troubleshooting

--- a/format/tmux/formater.go
+++ b/format/tmux/formater.go
@@ -18,8 +18,8 @@ type Config struct {
 	// Styles contains the tmux style strings for symbols and Git status
 	// components.
 	Styles styles
-	// Display sets the output format of the Git status.
-	Display []string `yaml:",flow"`
+	// Layout sets the output format of the Git status.
+	Layout []string `yaml:",flow"`
 }
 
 type symbols struct {
@@ -73,7 +73,7 @@ var DefaultCfg = Config{
 		Stashed:   "#[fg=cyan,bold]",
 		Clean:     "#[fg=green,bold]",
 	},
-	Display: []string{"branch", "..", "remote", " - ", "flags"},
+	Layout: []string{"branch", "..", "remote", " - ", "flags"},
 }
 
 // A Formater formats git status to a tmux style string.
@@ -102,7 +102,7 @@ func (f *Formater) Format(w io.Writer, st *gitstatus.Status) error {
 }
 
 func (f *Formater) format() {
-	for _, order := range f.Display {
+	for _, order := range f.Layout {
 		switch order {
 		case "branch":
 			f.specialState()

--- a/format/tmux/formater_test.go
+++ b/format/tmux/formater_test.go
@@ -2,7 +2,6 @@ package tmux
 
 import (
 	"os"
-	"regexp"
 	"testing"
 
 	"github.com/arl/gitstatus"
@@ -21,16 +20,16 @@ func TestFormater_flags(t *testing.T) {
 		{
 			name: "clean flag",
 			styles: styles{
-				Clean: "CleanStyle",
+				Clean: "StyleClean",
 			},
 			symbols: symbols{
-				Clean: "CleanSymbol",
+				Clean: "SymbolClean",
 			},
 			display: []string{"branch", "..", "remote", " - ", "flags"},
 			st: &gitstatus.Status{
 				IsClean: true,
 			},
-			want: clear + "CleanStyleCleanSymbol",
+			want: clear + "StyleCleanSymbolClean",
 		},
 		{
 			name: "mixed flags",
@@ -169,140 +168,103 @@ func TestFormater_Format(t *testing.T) {
 		symbols symbols
 		display []string
 		st      *gitstatus.Status
-		want    *regexp.Regexp
+		want    string
 	}{
 		{
 			name: "default format",
 			styles: styles{
-				Clean: "CleanStyle",
+				Clean:    "StyleClean",
+				Branch:   "StyleBranch",
+				Modified: "StyleMod",
+				Remote:   "StyleRemote",
 			},
 			symbols: symbols{
-				Branch: "⎇ ",
-				Clean:  "CleanSymbol",
+				Branch:   "SymbolBranch",
+				Clean:    "SymbolClean",
+				Modified: "SymbolMod",
 			},
 			display: []string{"branch", "..", "remote", " - ", "flags"},
 			st: &gitstatus.Status{
-				IsClean: true,
+				Porcelain: gitstatus.Porcelain{
+					LocalBranch:  "Local",
+					RemoteBranch: "Remote",
+					NumModified:  2,
+				},
 			},
-			want: regexp.MustCompile(`#\[fg=default]⎇ #\[fg=default][\w\/.-]+..(#\[fg=default][\w\/.-]+)?#\[fg=default] - #\[fg=default].+`),
+			want: clear + "StyleBranchSymbolBranch" + clear + "Local" + ".." + clear + "StyleRemoteRemote" + clear + " - " + clear + "StyleModSymbolMod2",
 		},
 		{
-			name: "default format with diff delimiters",
+			name: "branch, different delimiter, flags",
 			styles: styles{
-				Clean: "CleanStyle",
+				Branch:   "StyleBranch",
+				Remote:   "StyleRemote",
+				Modified: "StyleMod",
 			},
 			symbols: symbols{
-				Branch: "⎇ ",
-				Clean:  "CleanSymbol",
+				Branch:   "SymbolBranch",
+				Ahead:    "SymbolAhead",
+				Modified: "SymbolMod",
 			},
-			display: []string{"branch", "~~", "remote", " | ", "flags"},
+			display: []string{"branch", " ~~ ", "flags"},
 			st: &gitstatus.Status{
-				IsClean: true,
+				Porcelain: gitstatus.Porcelain{
+					LocalBranch:  "Local",
+					RemoteBranch: "Remote",
+					NumModified:  2,
+					AheadCount:   1,
+				},
 			},
-			want: regexp.MustCompile(`#\[fg=default]⎇ #\[fg=default][\w\/.-]+~~(#\[fg=default][\w\/.-]+)?#\[fg=default] | #\[fg=default].+`),
-		},
-		{
-			name: "no branch or delimiter0",
-			styles: styles{
-				Clean: "CleanStyle",
-			},
-			symbols: symbols{
-				Branch: "⎇ ",
-				Clean:  "CleanSymbol",
-			},
-			display: []string{"remote", " - ", "flags"},
-			st: &gitstatus.Status{
-				IsClean: true,
-			},
-			want: regexp.MustCompile(`(#\[fg=default][\w\/.-]+)?#\[fg=default] - #\[fg=default].+`),
-		},
-		{
-			name: "no remote and delimiter0",
-			styles: styles{
-				Clean: "CleanStyle",
-			},
-			symbols: symbols{
-				Branch: "⎇ ",
-				Clean:  "CleanSymbol",
-			},
-			display: []string{"branch", " - ", "flags"},
-			st: &gitstatus.Status{
-				IsClean: true,
-			},
-			want: regexp.MustCompile(`#\[fg=default]⎇ #\[fg=default][\w\/.-]+ - #\[fg=default].+`),
-		},
-		{
-			name: "branch only",
-			styles: styles{
-				Clean: "CleanStyle",
-			},
-			symbols: symbols{
-				Branch: "⎇ ",
-				Clean:  "CleanSymbol",
-			},
-			display: []string{"branch"},
-			st: &gitstatus.Status{
-				IsClean: true,
-			},
-			want: regexp.MustCompile(`#\[fg=default]⎇ #\[fg=default][\w\/.-]+`),
+			want: clear + "StyleBranchSymbolBranch" + clear + "Local" + " ~~ " + clear + "StyleModSymbolMod2",
 		},
 		{
 			name: "remote only",
 			styles: styles{
-				Clean: "CleanStyle",
+				Branch: "StyleBranch",
+				Remote: "StyleRemote",
 			},
 			symbols: symbols{
-				Branch: "⎇ ",
-				Clean:  "CleanSymbol",
+				Branch: "SymbolBranch",
+				Ahead:  "SymbolAhead",
 			},
 			display: []string{"remote"},
 			st: &gitstatus.Status{
-				IsClean: true,
+				Porcelain: gitstatus.Porcelain{
+					LocalBranch:  "Local",
+					RemoteBranch: "Remote",
+					AheadCount:   1,
+				},
 			},
-			want: regexp.MustCompile(`(#\[fg=default][\w\/.-]+)?#\[fg=default]`),
+			want: clear + "StyleRemoteRemote" + clear + " SymbolAhead1",
 		},
 		{
-			name: "flags only",
+			name: "empty",
 			styles: styles{
-				Clean: "CleanStyle",
+				Branch:   "StyleBranch",
+				Modified: "StyleMod",
 			},
 			symbols: symbols{
-				Branch: "⎇ ",
-				Clean:  "CleanSymbol",
+				Branch:   "SymbolBranch",
+				Modified: "SymbolMod",
 			},
-			display: []string{"flags"},
+			display: []string{},
 			st: &gitstatus.Status{
-				IsClean: true,
+				Porcelain: gitstatus.Porcelain{
+					LocalBranch: "Local",
+					NumModified: 2,
+				},
 			},
-			want: regexp.MustCompile(`#\[fg=default].+`),
-		},
-		{
-			name: "no delimiters",
-			styles: styles{
-				Clean: "CleanStyle",
-			},
-			symbols: symbols{
-				Branch: "⎇ ",
-				Clean:  "CleanSymbol",
-			},
-			display: []string{"branch", "remote", "flags"},
-			st: &gitstatus.Status{
-				IsClean: true,
-			},
-			want: regexp.MustCompile(`#\[fg=default]⎇ #\[fg=default][\w\/.-]+(#\[fg=default][\w\/.-]+)?#\[fg=default]#\[fg=default].+`),
+			want: "",
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			f := &Formater{
 				Config: Config{Styles: tc.styles, Symbols: tc.symbols, Display: tc.display},
-				st:     tc.st,
 			}
-			st, _ := gitstatus.New()
 
-			f.Format(os.Stdout, st)
+			f.Format(os.Stdout, tc.st)
 			f.format()
-			require.Regexp(t, tc.want, f.b.String())
+			require.EqualValues(t, tc.want, f.b.String())
 		})
 	}
 }

--- a/format/tmux/formater_test.go
+++ b/format/tmux/formater_test.go
@@ -1,6 +1,8 @@
 package tmux
 
 import (
+	"os"
+	"regexp"
 	"testing"
 
 	"github.com/arl/gitstatus"
@@ -12,6 +14,7 @@ func TestFormater_flags(t *testing.T) {
 		name    string
 		styles  styles
 		symbols symbols
+		display []string
 		st      *gitstatus.Status
 		want    string
 	}{
@@ -23,10 +26,11 @@ func TestFormater_flags(t *testing.T) {
 			symbols: symbols{
 				Clean: "CleanSymbol",
 			},
+			display: []string{"branch", "..", "remote", " - ", "flags"},
 			st: &gitstatus.Status{
 				IsClean: true,
 			},
-			want: clear + " - CleanStyleCleanSymbol",
+			want: clear + "CleanStyleCleanSymbol",
 		},
 		{
 			name: "mixed flags",
@@ -40,6 +44,7 @@ func TestFormater_flags(t *testing.T) {
 				Stashed:  "SymbolStash",
 				Staged:   "SymbolStaged",
 			},
+			display: []string{"branch", "..", "remote", " - ", "flags"},
 			st: &gitstatus.Status{
 				NumStashed: 1,
 				Porcelain: gitstatus.Porcelain{
@@ -47,7 +52,7 @@ func TestFormater_flags(t *testing.T) {
 					NumStaged:   3,
 				},
 			},
-			want: clear + " - StyleStagedSymbolStaged3 StyleModSymbolMod2 StyleStashSymbolStash1",
+			want: clear + "StyleStagedSymbolStaged3 StyleModSymbolMod2 StyleStashSymbolStash1",
 		},
 		{
 			name: "mixed flags 2",
@@ -65,13 +70,13 @@ func TestFormater_flags(t *testing.T) {
 					NumUntracked: 17,
 				},
 			},
-			want: clear + " - StyleConflictSymbolConflict42 StyleUntrackedSymbolUntracked17",
+			want: clear + "StyleConflictSymbolConflict42 StyleUntrackedSymbolUntracked17",
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			f := &Formater{
-				Config: Config{Styles: tc.styles, Symbols: tc.symbols},
+				Config: Config{Styles: tc.styles, Symbols: tc.symbols, Display: tc.display},
 				st:     tc.st,
 			}
 			f.flags()
@@ -153,6 +158,151 @@ func TestFormater_divergence(t *testing.T) {
 			}
 			f.divergence()
 			require.EqualValues(t, tc.want, f.b.String())
+		})
+	}
+}
+
+func TestFormater_Format(t *testing.T) {
+	tests := []struct {
+		name    string
+		styles  styles
+		symbols symbols
+		display []string
+		st      *gitstatus.Status
+		want    *regexp.Regexp
+	}{
+		{
+			name: "default format",
+			styles: styles{
+				Clean: "CleanStyle",
+			},
+			symbols: symbols{
+				Branch: "⎇ ",
+				Clean:  "CleanSymbol",
+			},
+			display: []string{"branch", "..", "remote", " - ", "flags"},
+			st: &gitstatus.Status{
+				IsClean: true,
+			},
+			want: regexp.MustCompile(`#\[fg=default]⎇ #\[fg=default][\w\/.-]+..(#\[fg=default][\w\/.-]+)?#\[fg=default] - #\[fg=default].+`),
+		},
+		{
+			name: "default format with diff delimiters",
+			styles: styles{
+				Clean: "CleanStyle",
+			},
+			symbols: symbols{
+				Branch: "⎇ ",
+				Clean:  "CleanSymbol",
+			},
+			display: []string{"branch", "~~", "remote", " | ", "flags"},
+			st: &gitstatus.Status{
+				IsClean: true,
+			},
+			want: regexp.MustCompile(`#\[fg=default]⎇ #\[fg=default][\w\/.-]+~~(#\[fg=default][\w\/.-]+)?#\[fg=default] | #\[fg=default].+`),
+		},
+		{
+			name: "no branch or delimiter0",
+			styles: styles{
+				Clean: "CleanStyle",
+			},
+			symbols: symbols{
+				Branch: "⎇ ",
+				Clean:  "CleanSymbol",
+			},
+			display: []string{"remote", " - ", "flags"},
+			st: &gitstatus.Status{
+				IsClean: true,
+			},
+			want: regexp.MustCompile(`(#\[fg=default][\w\/.-]+)?#\[fg=default] - #\[fg=default].+`),
+		},
+		{
+			name: "no remote and delimiter0",
+			styles: styles{
+				Clean: "CleanStyle",
+			},
+			symbols: symbols{
+				Branch: "⎇ ",
+				Clean:  "CleanSymbol",
+			},
+			display: []string{"branch", " - ", "flags"},
+			st: &gitstatus.Status{
+				IsClean: true,
+			},
+			want: regexp.MustCompile(`#\[fg=default]⎇ #\[fg=default][\w\/.-]+ - #\[fg=default].+`),
+		},
+		{
+			name: "branch only",
+			styles: styles{
+				Clean: "CleanStyle",
+			},
+			symbols: symbols{
+				Branch: "⎇ ",
+				Clean:  "CleanSymbol",
+			},
+			display: []string{"branch"},
+			st: &gitstatus.Status{
+				IsClean: true,
+			},
+			want: regexp.MustCompile(`#\[fg=default]⎇ #\[fg=default][\w\/.-]+`),
+		},
+		{
+			name: "remote only",
+			styles: styles{
+				Clean: "CleanStyle",
+			},
+			symbols: symbols{
+				Branch: "⎇ ",
+				Clean:  "CleanSymbol",
+			},
+			display: []string{"remote"},
+			st: &gitstatus.Status{
+				IsClean: true,
+			},
+			want: regexp.MustCompile(`(#\[fg=default][\w\/.-]+)?#\[fg=default]`),
+		},
+		{
+			name: "flags only",
+			styles: styles{
+				Clean: "CleanStyle",
+			},
+			symbols: symbols{
+				Branch: "⎇ ",
+				Clean:  "CleanSymbol",
+			},
+			display: []string{"flags"},
+			st: &gitstatus.Status{
+				IsClean: true,
+			},
+			want: regexp.MustCompile(`#\[fg=default].+`),
+		},
+		{
+			name: "no delimiters",
+			styles: styles{
+				Clean: "CleanStyle",
+			},
+			symbols: symbols{
+				Branch: "⎇ ",
+				Clean:  "CleanSymbol",
+			},
+			display: []string{"branch", "remote", "flags"},
+			st: &gitstatus.Status{
+				IsClean: true,
+			},
+			want: regexp.MustCompile(`#\[fg=default]⎇ #\[fg=default][\w\/.-]+(#\[fg=default][\w\/.-]+)?#\[fg=default]#\[fg=default].+`),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := &Formater{
+				Config: Config{Styles: tc.styles, Symbols: tc.symbols, Display: tc.display},
+				st:     tc.st,
+			}
+			st, _ := gitstatus.New()
+
+			f.Format(os.Stdout, st)
+			f.format()
+			require.Regexp(t, tc.want, f.b.String())
 		})
 	}
 }

--- a/format/tmux/formater_test.go
+++ b/format/tmux/formater_test.go
@@ -13,7 +13,7 @@ func TestFormater_flags(t *testing.T) {
 		name    string
 		styles  styles
 		symbols symbols
-		display []string
+		layout  []string
 		st      *gitstatus.Status
 		want    string
 	}{
@@ -25,7 +25,7 @@ func TestFormater_flags(t *testing.T) {
 			symbols: symbols{
 				Clean: "SymbolClean",
 			},
-			display: []string{"branch", "..", "remote", " - ", "flags"},
+			layout: []string{"branch", "..", "remote", " - ", "flags"},
 			st: &gitstatus.Status{
 				IsClean: true,
 			},
@@ -43,7 +43,7 @@ func TestFormater_flags(t *testing.T) {
 				Stashed:  "SymbolStash",
 				Staged:   "SymbolStaged",
 			},
-			display: []string{"branch", "..", "remote", " - ", "flags"},
+			layout: []string{"branch", "..", "remote", " - ", "flags"},
 			st: &gitstatus.Status{
 				NumStashed: 1,
 				Porcelain: gitstatus.Porcelain{
@@ -75,7 +75,7 @@ func TestFormater_flags(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			f := &Formater{
-				Config: Config{Styles: tc.styles, Symbols: tc.symbols, Display: tc.display},
+				Config: Config{Styles: tc.styles, Symbols: tc.symbols, Layout: tc.layout},
 				st:     tc.st,
 			}
 			f.flags()
@@ -166,7 +166,7 @@ func TestFormater_Format(t *testing.T) {
 		name    string
 		styles  styles
 		symbols symbols
-		display []string
+		layout  []string
 		st      *gitstatus.Status
 		want    string
 	}{
@@ -183,7 +183,7 @@ func TestFormater_Format(t *testing.T) {
 				Clean:    "SymbolClean",
 				Modified: "SymbolMod",
 			},
-			display: []string{"branch", "..", "remote", " - ", "flags"},
+			layout: []string{"branch", "..", "remote", " - ", "flags"},
 			st: &gitstatus.Status{
 				Porcelain: gitstatus.Porcelain{
 					LocalBranch:  "Local",
@@ -205,7 +205,7 @@ func TestFormater_Format(t *testing.T) {
 				Ahead:    "SymbolAhead",
 				Modified: "SymbolMod",
 			},
-			display: []string{"branch", " ~~ ", "flags"},
+			layout: []string{"branch", " ~~ ", "flags"},
 			st: &gitstatus.Status{
 				Porcelain: gitstatus.Porcelain{
 					LocalBranch:  "Local",
@@ -226,7 +226,7 @@ func TestFormater_Format(t *testing.T) {
 				Branch: "SymbolBranch",
 				Ahead:  "SymbolAhead",
 			},
-			display: []string{"remote"},
+			layout: []string{"remote"},
 			st: &gitstatus.Status{
 				Porcelain: gitstatus.Porcelain{
 					LocalBranch:  "Local",
@@ -246,7 +246,7 @@ func TestFormater_Format(t *testing.T) {
 				Branch:   "SymbolBranch",
 				Modified: "SymbolMod",
 			},
-			display: []string{},
+			layout: []string{},
 			st: &gitstatus.Status{
 				Porcelain: gitstatus.Porcelain{
 					LocalBranch: "Local",
@@ -259,7 +259,7 @@ func TestFormater_Format(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			f := &Formater{
-				Config: Config{Styles: tc.styles, Symbols: tc.symbols, Display: tc.display},
+				Config: Config{Styles: tc.styles, Symbols: tc.symbols, Layout: tc.layout},
 			}
 
 			f.Format(os.Stdout, tc.st)

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,7 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=


### PR DESCRIPTION
closes #14 

forked from cason's PR found here: https://github.com/arl/gitmux/pull/16

separately, i noticed that remote & divergence are coupled together. how do you feel about a separate PR to decouple those? (i don't feel strongly about that, so maybe we just leave it be)