### PR TITLE
format/tmux: add missing spaces after symbols

### DIFF
--- a/format/tmux/formater.go
+++ b/format/tmux/formater.go
@@ -52,10 +52,10 @@ type styles struct {
 var DefaultCfg = Config{
 	Symbols: symbols{
 		Branch:     "⎇ ",
-		Staged:     "●",
+		Staged:     "● ",
 		Conflict:   "✖ ",
 		Modified:   "✚ ",
-		Untracked:  "…",
+		Untracked:  "… ",
 		Stashed:    "⚑ ",
 		Clean:      "✔",
 		Ahead:      "↑·",


### PR DESCRIPTION
The 'staged' and 'untracked' symbols are both missing a trailing
space in the default configuration. With some fixed fonts (for
instance the stock Ubuntu font) this makes difficult to discern
between the symbol and the number following it.

Fixes #24