### PR TITLE
Breakdown remote component

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
  - **minimal**. Only show what you need when you need it
  - **discrete**. Disappear when current directory is not managed by Git
  - **shell-independent**. Work with sh, bash, zsh, fish, etc.
- - **highly configurable**. Colors and symbols can be customized
+ - **highly configurable**. Colors, symbols and layout can be customized
  - **automatic**. Information auto-updates with respect to the current working directory
 
 ## Prerequisites
@@ -53,31 +53,98 @@ Add this line to your  `.tmux.conf`:
 
 `gitmux` output can be customized via a configuration file in YAML format.
 
-First, save the default configuration to a new file
+The gitmux configuration file is in YAML format:
+
+```yaml
+tmux:
+  symbols:
+    branch: '⎇ '
+    hashprefix: ':'
+    ahead: ↑·
+    behind: ↓·
+    staged: '● '
+    conflict: '✖ '
+    modified: '✚ '
+    untracked: '… '
+    stashed: '⚑ '
+    clean: ✔
+  styles:
+    state: '#[fg=red,bold]'
+    branch: '#[fg=white,bold]'
+    remote: '#[fg=cyan]'
+    staged: '#[fg=green,bold]'
+    conflict: '#[fg=red,bold]'
+    modified: '#[fg=red,bold]'
+    untracked: '#[fg=magenta,bold]'
+    stashed: '#[fg=cyan,bold]'
+    clean: '#[fg=green,bold]'
+  layout: [branch, .., remote, ' - ', flags]
+```
+
+First, save the default configuration to a new file:
 
     gitmux -printcfg > .gitmux.conf
-
-Open `.gitmux.conf` and modify it, replacing symbols and colors to suit your needs.
-Ensure the file is valid by adding the `-dbg` flag
-
-    gitmux -dbg -cfg .gitmux.conf
 
 Modify the line in `.tmux.conf`, passing the path of the configuration file as argument to `gitmux`
 
     gitmux -cfg .gitmux.conf
 
+Open `.gitmux.conf` and modify it, replacing symbols, styles and layout to suit your needs.
+
+In `tmux` status bar, `gitmux` output immediately reflects the changes you make to the configuration.
+
 `gitmux` configuration is split into 3 sections:
- - symbols: they are just strings of unicode characters
- - styles: they are tmux format strings (`man tmux` for reference)
- - layout: is the layout of git components & separators
+ - `symbols`: they're just strings of unicode characters
+ - `styles`: tmux format strings
+ - `layout`: list of `gitmux` layout components, defines the component to show and in their order.
+
+
+### Symbols
+
+```yaml
+  symbols:
+    branch: '⎇ '      # shown before `branch`
+    hashprefix: ':'    # shown before a Git hash (in 'detached HEAD' state)
+    ahead: ↑·          # shown before 'ahead count' when local/remote branch diverges`
+    behind: ↓·         # shown before 'behind count' when local/remote branch diverges`
+    staged: '● '       # shown before the 'staged files' count
+    conflict: '✖ '     # shown before the 'conflicts' count
+    modified: '✚ '     # shown before the 'modified files' count
+    untracked: '… '    # shown before the 'untracked files' count
+    stashed: '⚑ '      # shown before the 'stash' count
+    clean: ✔           # shown when the working tree is clean
+```
+
+
+### Styles
+
+Styles are tmux format strings. For full reference, search for `message-command-style` 
+in `tmux` manual `man tmux`.
+
+
+### Layout components
+
+This is the list of the possible components of the `layout`:
+
+| Layout Component |                 Description                 |         Example        |
+|:----------------:|---------------------------------------------|:----------------------:|
+| `branch`         | Local branch name                           |        `master`        |
+| `remote`         | Remote branch name                          |     `origin/master`    |
+| `divergence`     | Divergence local/remote branch, if any      |        `↓·2↑·1`        |
+| `remote`         | Alias for `remote-branch divergence`        | `origin/master ↓·2↑·1` |
+| `flags`          | Symbols representing the working tree state |      `✚ 1 ⚑ 1 … 2`     |
+| any string `foo` | Any other string is directly shown          |          `foo`         |
+
+
 
 Example layouts:
 ```
 layout: [branch, '..', remote, ' - ', flags]
+layout: [branch, '..', remote-flags, divergence, ' - ', flags]
 layout: [branch]
-layout: [flags, ' && ', branch]
+layout: [flags, branch]
+layout: [flags, ~~~, branch]
 ```
-
 
 ## Troubleshooting
 

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+	"testing"
+)
+
+var updateGolden = flag.Bool("update", false, "update golden files")
+
+// This test ensures that new features do not change gitmux output when used
+// with a default configuration.
+func TestOutputNonRegression(t *testing.T) {
+	if testing.Short() {
+		t.Skipf("skipping in -short mode")
+	}
+
+	tmpdir, err := ioutil.TempDir("", t.Name())
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.RemoveAll(tmpdir)
+
+	t.Logf("test working directory: %q", tmpdir)
+	cloneAndHack(t, tmpdir)
+
+	cmd := exec.Command("go", "run", ".", "-printcfg")
+	b, err := cmd.CombinedOutput()
+	defcfg := path.Join(tmpdir, "default.cfg")
+	if err := ioutil.WriteFile(defcfg, b, os.ModePerm); err != nil {
+		t.Fatalf("Can't write %q: %s", defcfg, err)
+	}
+
+	repodir := path.Join(tmpdir, "gitmux")
+
+	cmd = exec.Command("go", "run", ".", "-cfg", defcfg, repodir)
+	got, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Command %q failed:\n%s\nerr: %s", cmdString(cmd), b, err)
+	}
+
+	goldenFile := path.Join("testdata", "default.output.golden")
+
+	if *updateGolden {
+		if err := ioutil.WriteFile(goldenFile, got, os.ModePerm); err != nil {
+			t.Fatalf("Can't update golden file %q: %s", goldenFile, err)
+		}
+	}
+
+	want, err := ioutil.ReadFile(goldenFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(want, got) {
+		t.Fatalf("got:\n%s\nwant:\n%s", want, got)
+	}
+}
+
+func cmdString(cmd *exec.Cmd) string {
+	return strings.Join(append([]string{cmd.Path}, cmd.Args...), " ")
+}
+
+func run(t *testing.T, name string, args ...string) {
+	t.Helper()
+
+	cmd := exec.Command(name, args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Command %q failed:\n%s\nerr: %s", cmdString(cmd), out, err)
+	}
+}
+
+func cloneAndHack(t *testing.T, dir string) {
+	t.Helper()
+
+	var popdir func() error
+	var err error
+
+	if popdir, err = pushdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer popdir()
+
+	run(t, "git", "clone", "git://github.com/arl/gitmux.git")
+
+	if popdir, err = pushdir("gitmux"); err != nil {
+		t.Fatal(err)
+	}
+	defer popdir()
+
+	if err := ioutil.WriteFile("dummy", []byte("dummy"), os.ModePerm); err != nil {
+		t.Fatalf("write dummy: %s", err)
+	}
+	run(t, "git", "add", "dummy")
+	run(t, "git", "commit", "-m", "add dummy file")
+
+	if err := ioutil.WriteFile("dummy2", []byte("dummy2"), os.ModePerm); err != nil {
+		t.Fatalf("write dummy2: %s", err)
+	}
+	run(t, "git", "add", "dummy2")
+	run(t, "git", "stash")
+
+	if err := ioutil.WriteFile("file1", nil, os.ModePerm); err != nil {
+		t.Fatalf("write file1: %s", err)
+	}
+	if err := ioutil.WriteFile("file2", nil, os.ModePerm); err != nil {
+		t.Fatalf("write file2: %s", err)
+	}
+	if err := ioutil.WriteFile("file3", nil, os.ModePerm); err != nil {
+		t.Fatalf("write file3: %s", err)
+	}
+
+	run(t, "git", "add", "file1")
+	run(t, "git", "add", "file2")
+	if err := ioutil.WriteFile("file2", []byte("foo"), os.ModePerm); err != nil {
+		t.Fatalf("write file2: %s", err)
+	}
+}

--- a/format/tmux/formater.go
+++ b/format/tmux/formater.go
@@ -103,16 +103,20 @@ func (f *Formater) Format(w io.Writer, st *gitstatus.Status) error {
 }
 
 func (f *Formater) format() {
-	for _, order := range f.Layout {
-		switch order {
+	for _, item := range f.Layout {
+		switch item {
 		case "branch":
 			f.specialState()
 		case "remote":
 			f.remote()
+		case "remote-branch":
+			f.remoteBranch()
+		case "divergence":
+			f.divergence()
 		case "flags":
 			f.flags()
 		default:
-			f.b.WriteString(order)
+			f.b.WriteString(item)
 		}
 	}
 }
@@ -148,19 +152,11 @@ func (f *Formater) remote() {
 	}
 }
 
-func (f *Formater) clear() {
-	// clear global style
-	f.b.WriteString(clear)
-}
-
-func (f *Formater) currentRef() {
+func (f *Formater) remoteBranch() {
 	f.clear()
-	if f.st.IsDetached {
-		fmt.Fprintf(&f.b, "%s%s", f.Symbols.HashPrefix, f.st.HEAD)
-		return
+	if f.st.RemoteBranch != "" {
+		fmt.Fprintf(&f.b, "%s%s", f.Styles.Remote, f.st.RemoteBranch)
 	}
-
-	fmt.Fprintf(&f.b, "%s", f.st.LocalBranch)
 }
 
 func (f *Formater) divergence() {
@@ -175,6 +171,21 @@ func (f *Formater) divergence() {
 	if f.st.AheadCount != 0 {
 		fmt.Fprintf(&f.b, "%s%s%d", pref, f.Symbols.Ahead, f.st.AheadCount)
 	}
+}
+
+func (f *Formater) clear() {
+	// clear global style
+	f.b.WriteString(clear)
+}
+
+func (f *Formater) currentRef() {
+	f.clear()
+	if f.st.IsDetached {
+		fmt.Fprintf(&f.b, "%s%s", f.Symbols.HashPrefix, f.st.HEAD)
+		return
+	}
+
+	fmt.Fprintf(&f.b, "%s", f.st.LocalBranch)
 }
 
 func (f *Formater) flags() {

--- a/format/tmux/formater.go
+++ b/format/tmux/formater.go
@@ -74,7 +74,7 @@ var DefaultCfg = Config{
 		Stashed:   "#[fg=cyan,bold]",
 		Clean:     "#[fg=green,bold]",
 	},
-	Layout: []string{"branch", "..", "remote", " - ", "flags"},
+	Layout: []string{"branch", "..", "remote-branch", "divergence", " - ", "flags"},
 }
 
 // A Formater formats git status to a tmux style string.

--- a/format/tmux/formater.go
+++ b/format/tmux/formater.go
@@ -49,6 +49,7 @@ type styles struct {
 	Clean     string // Clean is the style string printed before the clean symbols.
 }
 
+// DefaultCfg is the default tmux configuration.
 var DefaultCfg = Config{
 	Symbols: symbols{
 		Branch:     "⎇ ",

--- a/format/tmux/formater_test.go
+++ b/format/tmux/formater_test.go
@@ -4,8 +4,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/arl/gitstatus"
 	"github.com/stretchr/testify/require"
+
+	"github.com/arl/gitstatus"
 )
 
 func TestFormater_flags(t *testing.T) {

--- a/gitmux.go
+++ b/gitmux.go
@@ -37,8 +37,8 @@ func parseOptions() (dir string, dbg bool, cfg Config) {
 	cfgOpt := flag.String("cfg", "", "")
 	printCfgOpt := flag.Bool("printcfg", false, "")
 	versionOpt := flag.Bool("V", false, "")
-	flag.Bool("q", true, "")   // unused, kept for retrocompatibility.
-	flag.String("fmt", "", "") // unused, kept for retrocompatibility.
+	flag.Bool("q", true, "")   // unused, kept for retro-compatibility.
+	flag.String("fmt", "", "") // unused, kept for retro-compatibility.
 	flag.Usage = func() {
 		fmt.Println(usage)
 	}

--- a/testdata/default.output.golden
+++ b/testdata/default.output.golden
@@ -1,0 +1,1 @@
+#[fg=default]#[fg=default]#[fg=white,bold]⎇ #[fg=default]master..#[fg=default]#[fg=cyan]origin/master#[fg=default] ↑·1 - #[fg=default]#[fg=green,bold]● 1 #[fg=red,bold]✚ 1 #[fg=cyan,bold]⚑ 1 #[fg=magenta,bold]… 1


### PR DESCRIPTION
Currently the `remote` flags gets replaced in `gitmux` output by both the name of the remote (e.g `origin`) and the divergence flags indicating whether the local and the remote branch diverges and how much (e.g `↓·2↑·3`).

In order to allow user to skip the remote branch and to keep the divergence flags, or the other way around, we add the `remote-branch` and the `divergence` layout elements.

Also, to not break user configurations, we keep the 'remote' layout element as an alias for `remote-flags, divergence`.

Fixes #23

