### PR TITLE
Add option to truncate long branch names

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ tmux:
     stashed: '#[fg=cyan,bold]'
     clean: '#[fg=green,bold]'
   layout: [branch, .., remote, ' - ', flags]
+  options:
+    branch_max_len: 0
 ```
 
 First, save the default configuration to a new file:
@@ -93,10 +95,11 @@ Open `.gitmux.conf` and modify it, replacing symbols, styles and layout to suit 
 
 In `tmux` status bar, `gitmux` output immediately reflects the changes you make to the configuration.
 
-`gitmux` configuration is split into 3 sections:
+`gitmux` configuration is split into 4 sections:
  - `symbols`: they're just strings of unicode characters
  - `styles`: tmux format strings
  - `layout`: list of `gitmux` layout components, defines the component to show and in their order.
+ - `options`: additional configuration options
 
 
 ### Symbols
@@ -145,6 +148,16 @@ layout: [branch]
 layout: [flags, branch]
 layout: [flags, ~~~, branch]
 ```
+
+
+### Additional options
+
+This is the list of additional configuration `options`:
+
+| Option           | Description                                                | Default        |
+|:-----------------|:-----------------------------------------------------------|:---------------|
+| `branch_max_len` | Maximum displayed length for local and remote branch names | `0` (no limit) |
+
 
 ## Troubleshooting
 

--- a/format/tmux/formater.go
+++ b/format/tmux/formater.go
@@ -109,22 +109,20 @@ func truncateBranchName(name string, maxlen int, isremote bool) string {
 		}
 	}
 
-	truncatedName := branchName
-
 	// To count length of characters and extract substring from UTF-8 strings.
-	branchRune := []rune(branchName)
+	branchNameRune := []rune(branchName)
 	truncateSymbolRune := []rune(truncateSymbol)
 
-	if maxlen > 0 && maxlen < len(branchRune) {
+	if maxlen > 0 && maxlen < len(branchNameRune) {
 		nameLen := maxlen - len(truncateSymbolRune)
 		if nameLen > 0 {
-			truncatedName = string(branchRune[:nameLen]) + truncateSymbol
+			branchName = string(branchNameRune[:nameLen]) + truncateSymbol
 		} else {
-			truncatedName = string(truncateSymbolRune[:maxlen])
+			branchName = string(truncateSymbolRune[:maxlen])
 		}
 	}
 
-	return remoteName + truncatedName
+	return remoteName + branchName
 }
 
 // Format writes st as json into w.

--- a/format/tmux/formater.go
+++ b/format/tmux/formater.go
@@ -10,6 +10,7 @@ import (
 )
 
 const clear string = "#[fg=default]"
+const truncateSymbol string = "..."
 
 // Config is the configuration of the Git status tmux formatter.
 type Config struct {
@@ -20,6 +21,8 @@ type Config struct {
 	Styles styles
 	// Layout sets the output format of the Git status.
 	Layout []string `yaml:",flow"`
+	// Options contains additional configuration options.
+	Options options
 }
 
 type symbols struct {
@@ -49,6 +52,11 @@ type styles struct {
 	Clean     string // Clean is the style string printed before the clean symbols.
 }
 
+type options struct {
+	// BranchMaxLen is the maximum displayed length for local and remote branch names.
+	BranchMaxLen int `yaml:"branch_max_len"`
+}
+
 // DefaultCfg is the default tmux configuration.
 var DefaultCfg = Config{
 	Symbols: symbols{
@@ -75,6 +83,9 @@ var DefaultCfg = Config{
 		Clean:     "#[fg=green,bold]",
 	},
 	Layout: []string{"branch", "..", "remote-branch", "divergence", " - ", "flags"},
+	Options: options{
+		BranchMaxLen: 0,
+	},
 }
 
 // A Formater formats git status to a tmux style string.
@@ -84,6 +95,38 @@ type Formater struct {
 	st *gitstatus.Status
 }
 
+// Truncates branch name if longer than maxlen. If isremote, the leading
+// "<remote>/" is ignored when counting length.
+func truncateBranchName(name string, maxlen int, isremote bool) string {
+	remoteName := ""
+	branchName := name
+
+	if isremote {
+		a := strings.SplitAfterN(name, "/", 2)
+		if len(a) == 2 {
+			remoteName = a[0]
+			branchName = a[1]
+		}
+	}
+
+	truncatedName := branchName
+
+	// To count length of characters and extract substring from UTF-8 strings.
+	branchRune := []rune(branchName)
+	truncateSymbolRune := []rune(truncateSymbol)
+
+	if maxlen > 0 && maxlen < len(branchRune) {
+		nameLen := maxlen - len(truncateSymbolRune)
+		if nameLen > 0 {
+			truncatedName = string(branchRune[:nameLen]) + truncateSymbol
+		} else {
+			truncatedName = string(truncateSymbolRune[:maxlen])
+		}
+	}
+
+	return remoteName + truncatedName
+}
+
 // Format writes st as json into w.
 func (f *Formater) Format(w io.Writer, st *gitstatus.Status) error {
 	f.st = st
@@ -91,7 +134,8 @@ func (f *Formater) Format(w io.Writer, st *gitstatus.Status) error {
 
 	// overall working tree state
 	if f.st.IsInitial {
-		fmt.Fprintf(w, "%s%s [no commits yet]", f.Styles.Branch, f.st.LocalBranch)
+		fmt.Fprintf(w, "%s%s [no commits yet]", f.Styles.Branch,
+			truncateBranchName(f.st.LocalBranch, f.Options.BranchMaxLen, false))
 		f.flags()
 		_, err := f.b.WriteTo(w)
 		return err
@@ -147,7 +191,8 @@ func (f *Formater) specialState() {
 func (f *Formater) remote() {
 	f.clear()
 	if f.st.RemoteBranch != "" {
-		fmt.Fprintf(&f.b, "%s%s", f.Styles.Remote, f.st.RemoteBranch)
+		fmt.Fprintf(&f.b, "%s%s", f.Styles.Remote,
+			truncateBranchName(f.st.RemoteBranch, f.Options.BranchMaxLen, true))
 		f.divergence()
 	}
 }
@@ -155,7 +200,8 @@ func (f *Formater) remote() {
 func (f *Formater) remoteBranch() {
 	f.clear()
 	if f.st.RemoteBranch != "" {
-		fmt.Fprintf(&f.b, "%s%s", f.Styles.Remote, f.st.RemoteBranch)
+		fmt.Fprintf(&f.b, "%s%s", f.Styles.Remote,
+			truncateBranchName(f.st.RemoteBranch, f.Options.BranchMaxLen, true))
 	}
 }
 
@@ -185,7 +231,8 @@ func (f *Formater) currentRef() {
 		return
 	}
 
-	fmt.Fprintf(&f.b, "%s", f.st.LocalBranch)
+	fmt.Fprintf(&f.b, "%s",
+		truncateBranchName(f.st.LocalBranch, f.Options.BranchMaxLen, false))
 }
 
 func (f *Formater) flags() {

--- a/format/tmux/formater_test.go
+++ b/format/tmux/formater_test.go
@@ -162,90 +162,61 @@ func TestFormater_divergence(t *testing.T) {
 	}
 }
 
-func TestFormater_BranchMaxLen(t *testing.T) {
+func TestFormater_truncateBranchName(t *testing.T) {
 	tests := []struct {
-		name    string
-		styles  styles
-		symbols symbols
-		options options
-		st      *gitstatus.Status
-		want    string
+		name       string
+		branchName string
+		maxLen     int
+		isRemote   bool
+		want       string
 	}{
 		{
 			name: "no limit",
-			options: options{
-				BranchMaxLen: 0,
-			},
-			st: &gitstatus.Status{
-				Porcelain: gitstatus.Porcelain{
-					LocalBranch: "foo/bar-baz",
-					RemoteBranch: "remote/foo/bar-baz",
-				},
-			},
-			want: clear + "foo/bar-baz" + clear + "remote/foo/bar-baz",
+			branchName: "foo/bar-baz",
+			maxLen: 0,
+			isRemote: false,
+			want: "foo/bar-baz",
 		},
 		{
 			name: "no truncate",
-			options: options{
-				BranchMaxLen: 11,
-			},
-			st: &gitstatus.Status{
-				Porcelain: gitstatus.Porcelain{
-					LocalBranch: "foo/bar-baz",
-					RemoteBranch: "remote/foo/bar-baz",
-				},
-			},
-			want: clear + "foo/bar-baz" + clear + "remote/foo/bar-baz",
+			branchName: "foo/bar-baz",
+			maxLen: 11,
+			isRemote: false,
+			want: "foo/bar-baz",
 		},
 		{
 			name: "truncate",
-			options: options{
-				BranchMaxLen: 10,
-			},
-			st: &gitstatus.Status{
-				Porcelain: gitstatus.Porcelain{
-					LocalBranch: "foo/bar-baz",
-					RemoteBranch: "remote/foo/bar-baz",
-				},
-			},
-			want: clear + "foo/bar..." + clear + "remote/foo/bar...",
+			branchName: "foo/bar-baz",
+			maxLen: 10,
+			isRemote: false,
+			want: "foo/bar...",
+		},
+		{
+			name: "truncate remote",
+			branchName: "remote/foo/bar-baz",
+			maxLen: 10,
+			isRemote: true,
+			want: "remote/foo/bar...",
 		},
 		{
 			name: "truncate to 1",
-			options: options{
-				BranchMaxLen: 1,
-			},
-			st: &gitstatus.Status{
-				Porcelain: gitstatus.Porcelain{
-					LocalBranch: "foo/bar-baz",
-					RemoteBranch: "remote/foo/bar-baz",
-				},
-			},
-			want: clear + "." + clear + "remote/.",
+			branchName: "foo/bar-baz",
+			maxLen: 1,
+			isRemote: false,
+			want: ".",
 		},
 		{
 			name: "truncate utf-8 name",
-			options: options{
-				BranchMaxLen: 9,
-			},
-			st: &gitstatus.Status{
-				Porcelain: gitstatus.Porcelain{
-					LocalBranch: "foo/测试这个名字",
-					RemoteBranch: "remote/foo/测试这个名字",
-				},
-			},
-			want: clear + "foo/测试..." + clear + "remote/foo/测试...",
+			branchName: "foo/测试这个名字",
+			maxLen: 9,
+			isRemote: false,
+			want: "foo/测试...",
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			f := &Formater{
-				Config: Config{Options: tc.options},
-				st:     tc.st,
-			}
-			f.currentRef()
-			f.remoteBranch()
-			require.EqualValues(t, tc.want, f.b.String())
+			branchName := truncateBranchName(tc.branchName, tc.maxLen, tc.isRemote)
+			require.EqualValues(t, tc.want, branchName)
 		})
 	}
 }
@@ -256,6 +227,7 @@ func TestFormater_Format(t *testing.T) {
 		styles  styles
 		symbols symbols
 		layout  []string
+		options options
 		st      *gitstatus.Status
 		want    string
 	}{
@@ -344,11 +316,32 @@ func TestFormater_Format(t *testing.T) {
 			},
 			want: "",
 		},
+		{
+			name: "branch and remote, branch_max_len not zero",
+			styles: styles{
+				Branch:   "StyleBranch",
+				Remote:   "StyleRemote",
+			},
+			symbols: symbols{
+				Branch:   "SymbolBranch",
+			},
+			layout: []string{"branch", " ", "remote"},
+			options: options{
+				BranchMaxLen: 9,
+			},
+			st: &gitstatus.Status{
+				Porcelain: gitstatus.Porcelain{
+					LocalBranch:  "branchName",
+					RemoteBranch: "remote/branchName",
+				},
+			},
+			want: clear + "StyleBranch" + "SymbolBranch" + clear + "branch..." + " " + clear + "StyleRemote" + "remote/branch..." + clear,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			f := &Formater{
-				Config: Config{Styles: tc.styles, Symbols: tc.symbols, Layout: tc.layout},
+				Config: Config{Styles: tc.styles, Symbols: tc.symbols, Layout: tc.layout, Options: tc.options},
 			}
 
 			f.Format(os.Stdout, tc.st)

--- a/format/tmux/formater_test.go
+++ b/format/tmux/formater_test.go
@@ -162,6 +162,94 @@ func TestFormater_divergence(t *testing.T) {
 	}
 }
 
+func TestFormater_BranchMaxLen(t *testing.T) {
+	tests := []struct {
+		name    string
+		styles  styles
+		symbols symbols
+		options options
+		st      *gitstatus.Status
+		want    string
+	}{
+		{
+			name: "no limit",
+			options: options{
+				BranchMaxLen: 0,
+			},
+			st: &gitstatus.Status{
+				Porcelain: gitstatus.Porcelain{
+					LocalBranch: "foo/bar-baz",
+					RemoteBranch: "remote/foo/bar-baz",
+				},
+			},
+			want: clear + "foo/bar-baz" + clear + "remote/foo/bar-baz",
+		},
+		{
+			name: "no truncate",
+			options: options{
+				BranchMaxLen: 11,
+			},
+			st: &gitstatus.Status{
+				Porcelain: gitstatus.Porcelain{
+					LocalBranch: "foo/bar-baz",
+					RemoteBranch: "remote/foo/bar-baz",
+				},
+			},
+			want: clear + "foo/bar-baz" + clear + "remote/foo/bar-baz",
+		},
+		{
+			name: "truncate",
+			options: options{
+				BranchMaxLen: 10,
+			},
+			st: &gitstatus.Status{
+				Porcelain: gitstatus.Porcelain{
+					LocalBranch: "foo/bar-baz",
+					RemoteBranch: "remote/foo/bar-baz",
+				},
+			},
+			want: clear + "foo/bar..." + clear + "remote/foo/bar...",
+		},
+		{
+			name: "truncate to 1",
+			options: options{
+				BranchMaxLen: 1,
+			},
+			st: &gitstatus.Status{
+				Porcelain: gitstatus.Porcelain{
+					LocalBranch: "foo/bar-baz",
+					RemoteBranch: "remote/foo/bar-baz",
+				},
+			},
+			want: clear + "." + clear + "remote/.",
+		},
+		{
+			name: "truncate utf-8 name",
+			options: options{
+				BranchMaxLen: 9,
+			},
+			st: &gitstatus.Status{
+				Porcelain: gitstatus.Porcelain{
+					LocalBranch: "foo/测试这个名字",
+					RemoteBranch: "remote/foo/测试这个名字",
+				},
+			},
+			want: clear + "foo/测试..." + clear + "remote/foo/测试...",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := &Formater{
+				Config: Config{Options: tc.options},
+				st:     tc.st,
+			}
+			f.currentRef()
+			f.remoteBranch()
+			require.EqualValues(t, tc.want, f.b.String())
+		})
+	}
+}
+
 func TestFormater_Format(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
The PR is still work-in-progress (the name of the branch is obviously motivating the PR =]), I just wanted to discuss a couple of things before continuing.

1. First, the `options` struct currently looks like this
    ```go
    type options struct {
    	// BranchMaxLen is the maximum length for local and remote branch names.
     	BranchMaxLen int `yaml:"branch_max_len"`
    }
    ```
    that is, the field tag specifies the YAML key explicitely, in order to get the `branch_max_len` option in YAML from the camel-case `BranchMaxLen` (from https://godoc.org/gopkg.in/yaml.v2#Marshal). Is this ok?

2. Then, I was wondering if it would be nice to show when the branch name is being truncated, e.g. by appending a symbol at the end of the truncated name. For instance, `30-add-option-to-truncate-long-branch-names` becomes
    ```
    30-add-option-to-truncate-long>
    ```
    This could avoid ambiguity, or even mistakes, if a user is relying on `gitmux`'s output to perform some Git actions somewhere.

3. Although I didn't see this in the rest of the code, I'm splitting very long lines. Do you have a suggested guideline?

Thanks in advance!

---

Closes #30.