### PR TITLE
Fix use of clear

### DIFF
--- a/format/tmux/formater.go
+++ b/format/tmux/formater.go
@@ -166,6 +166,7 @@ func (f *Formater) format() {
 		case "flags":
 			f.flags()
 		default:
+			f.clear()
 			f.b.WriteString(item)
 		}
 	}
@@ -197,36 +198,41 @@ func (f *Formater) specialState() {
 }
 
 func (f *Formater) remote() {
+	if f.st.RemoteBranch == "" {
+		return
+	}
+
 	f.clear()
 
-	if f.st.RemoteBranch != "" {
-		fmt.Fprintf(&f.b, "%s%s", f.Styles.Remote,
-			truncateBranchName(f.st.RemoteBranch, f.Options.BranchMaxLen, true))
-		f.divergence()
-	}
+	fmt.Fprintf(&f.b, "%s%s", f.Styles.Remote,
+		truncateBranchName(f.st.RemoteBranch, f.Options.BranchMaxLen, true))
+	f.divergence()
 }
 
 func (f *Formater) remoteBranch() {
-	f.clear()
-
 	if f.st.RemoteBranch != "" {
+		f.clear()
+
 		fmt.Fprintf(&f.b, "%s%s", f.Styles.Remote,
 			truncateBranchName(f.st.RemoteBranch, f.Options.BranchMaxLen, true))
 	}
 }
 
 func (f *Formater) divergence() {
-	f.clear()
-
 	pref := " "
 
 	if f.st.BehindCount != 0 {
+		f.clear()
 		fmt.Fprintf(&f.b, " %s%d", f.Symbols.Behind, f.st.BehindCount)
 
 		pref = ""
 	}
 
 	if f.st.AheadCount != 0 {
+		if f.st.BehindCount == 0 {
+			f.clear()
+		}
+
 		fmt.Fprintf(&f.b, "%s%s%d", pref, f.Symbols.Ahead, f.st.AheadCount)
 	}
 }
@@ -250,9 +256,8 @@ func (f *Formater) currentRef() {
 }
 
 func (f *Formater) flags() {
-	f.clear()
-
 	if f.st.IsClean {
+		f.clear()
 		fmt.Fprintf(&f.b, "%s%s", f.Styles.Clean, f.Symbols.Clean)
 
 		return
@@ -285,5 +290,8 @@ func (f *Formater) flags() {
 			fmt.Sprintf("%s%s%d", f.Styles.Untracked, f.Symbols.Untracked, f.st.NumUntracked))
 	}
 
-	f.b.WriteString(strings.Join(flags, " "))
+	if len(flags) > 0 {
+		f.clear()
+		f.b.WriteString(strings.Join(flags, " "))
+	}
 }

--- a/format/tmux/formater_test.go
+++ b/format/tmux/formater_test.go
@@ -106,7 +106,7 @@ func TestDivergence(t *testing.T) {
 					BehindCount: 0,
 				},
 			},
-			want: clear,
+			want: "",
 		},
 		{
 			name: "ahead only",
@@ -256,7 +256,8 @@ func TestFormat(t *testing.T) {
 				},
 			},
 			want: clear + "StyleBranchSymbolBranch" +
-				clear + "StyleBranch" + "Local" + ".." +
+				clear + "StyleBranch" + "Local" +
+				clear + ".." +
 				clear + "StyleRemoteRemote" +
 				clear + " - " +
 				clear + "StyleModSymbolMod2",
@@ -283,7 +284,8 @@ func TestFormat(t *testing.T) {
 				},
 			},
 			want: clear + "StyleBranchSymbolBranch" +
-				clear + "StyleBranch" + "Local" + " ~~ " +
+				clear + "StyleBranch" + "Local" +
+				clear + " ~~ " +
 				clear + "StyleModSymbolMod2",
 		},
 		{
@@ -346,9 +348,9 @@ func TestFormat(t *testing.T) {
 				},
 			},
 			want: clear + "StyleBranch" + "SymbolBranch" +
-				clear + "StyleBranch" + "branch..." + " " +
-				clear + "StyleRemote" + "remote/branch..." +
-				clear,
+				clear + "StyleBranch" + "branch..." +
+				clear + " " +
+				clear + "StyleRemote" + "remote/branch...",
 		},
 		{
 			name: "issue-32",

--- a/testdata/default.output.golden
+++ b/testdata/default.output.golden
@@ -1,1 +1,1 @@
-#[fg=default]#[fg=default]#[fg=white,bold]⎇ #[fg=default]#[fg=white,bold]master..#[fg=default]#[fg=cyan]origin/master#[fg=default] ↑·1 - #[fg=default]#[fg=green,bold]● 1 #[fg=red,bold]✚ 1 #[fg=cyan,bold]⚑ 1 #[fg=magenta,bold]… 1
+#[fg=default]#[fg=default]#[fg=white,bold]⎇ #[fg=default]#[fg=white,bold]master#[fg=default]..#[fg=default]#[fg=cyan]origin/master#[fg=default] ↑·1#[fg=default] - #[fg=default]#[fg=green,bold]● 1 #[fg=red,bold]✚ 1 #[fg=cyan,bold]⚑ 1 #[fg=magenta,bold]… 1


### PR DESCRIPTION
Tmux format string `#fg=default` clears the foreground and is used before applying styles to the elements of the gitmux format string.

Now, we only call `clear()` before an element that is actually being printed.
Also we call `clear()` before printing non-keywords strings appearing in `Config.Layout`.

Fix tests and non-regression test