### PR TITLE
Issue 37/second try

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/arl/gitmux
 go 1.10
 
 require (
-	github.com/arl/gitstatus v0.4.2
+	github.com/arl/gitstatus v0.4.3
 	github.com/stretchr/testify v1.3.0
 	gopkg.in/yaml.v2 v2.2.4
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/arl/gitstatus v0.4.2 h1:PwUErrD3BV5E2wcbdvI2LewmWhDiFcRGwR6z4eGr0Bc=
-github.com/arl/gitstatus v0.4.2/go.mod h1:pEiL+vLLz99X0m5G4MySAt4o0fQw2yUbFeq2s7sMUzY=
+github.com/arl/gitstatus v0.4.3 h1:ad4Fk4uXRy7WRvK6UMKD1ijvElFN/ugvqzDWJo00pJs=
+github.com/arl/gitstatus v0.4.3/go.mod h1:pEiL+vLLz99X0m5G4MySAt4o0fQw2yUbFeq2s7sMUzY=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
## Purpose
Use `-timeout` option to create a context.Context and pass it to `gitstatus.NewWithContext`.

## Approach
_How does this change address the problem?_

`gitstatus.NewWithContext` is a new API of gitstatus that has been added exactly to handle this use case.
`gitstatus.NewWithContext` starts various suprocesses, all those now receive the same context.
