### PR TITLE
Add TPM configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/gitmux
+/gitmux.conf

--- a/tmux-gitmux.tmux
+++ b/tmux-gitmux.tmux
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+BINARY="$CURRENT_DIR/gitmux"
+CONFIG="$CURRENT_DIR/gitmux.conf"
+
+if [ ! -f "$BINARY" ]; then
+  tmux split-window "cd $CURRENT_DIR && go build -o gitmux && echo 'Press any key to continue...' && read -k1"
+fi
+
+if [ ! -f "$CONFIG" ]; then
+  ( cd "$CURRENT_DIR" ; ./gitmux -printcfg > gitmux.conf )
+fi


### PR DESCRIPTION
## Purpose

Add TPM configuration to make installation easier.

## Approach

Compile `gitmux` automatically, if the binary isn't in the plugin directory, and generate the default configuration.

You can use something like this in your Tmux configuration:

``` conf
set -g @plugin 'jcf/gitmux'
set -g status-right '#(~/.config/tmux/plugins/gitmux/gitmux -cfg ~/.config/tmux/plugins/gitmux/gitmux.conf "#{pane_current_path}")'
```

If `gitmux` works without a configuration file, you could skip generating the config file, and that would simplify the `status-right` option.

I'm not sure if this is something you want to merge based on #2, but I thought I'd share for anyone else who wants to run this awesome project alongside [TPM](https://github.com/tmux-plugins/tpm).

All the best!
