### PR TITLE
Issue 58/trim from left branch name

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,36 +59,37 @@ Note that `tmux v2.1` was released in 2015 so you're probably better off updatin
 
 `gitmux` output can be customized via a configuration file in YAML format.
 
-The gitmux configuration file is in YAML format.
+This is the default gitmux configuration file, in YAML format:
 
 ```yaml
 tmux:
-  symbols:
-    branch: '⎇ '
-    hashprefix: ':'
-    ahead: ↑·
-    behind: ↓·
-    staged: '● '
-    conflict: '✖ '
-    modified: '✚ '
-    untracked: '… '
-    stashed: '⚑ '
-    clean: ✔
-  styles:
-    clear: '#[fg=default]'
-    state: '#[fg=red,bold]'
-    branch: '#[fg=white,bold]'
-    remote: '#[fg=cyan]'
-    staged: '#[fg=green,bold]'
-    conflict: '#[fg=red,bold]'
-    modified: '#[fg=red,bold]'
-    untracked: '#[fg=magenta,bold]'
-    stashed: '#[fg=cyan,bold]'
-    clean: '#[fg=green,bold]'
-    divergence: "#[fg=yellow]"    
-  layout: [branch, .., remote, " - ", flags]
-  options:
-    branch_max_len: 0
+    symbols:
+        branch: '⎇ '
+        hashprefix: ':'
+        ahead: ↑·
+        behind: ↓·
+        staged: '● '
+        conflict: '✖ '
+        modified: '✚ '
+        untracked: '… '
+        stashed: '⚑ '
+        clean: ✔
+    styles:
+        clear: '#[fg=default]'
+        state: '#[fg=red,bold]'
+        branch: '#[fg=white,bold]'
+        remote: '#[fg=cyan]'
+        staged: '#[fg=green,bold]'
+        conflict: '#[fg=red,bold]'
+        modified: '#[fg=red,bold]'
+        untracked: '#[fg=magenta,bold]'
+        stashed: '#[fg=cyan,bold]'
+        clean: '#[fg=green,bold]'
+        divergence: '#[fg=default]'
+    layout: [branch, .., remote-branch, divergence, ' - ', flags]
+    options:
+        branch_max_len: 0
+        branch_trim: right
 ```
 
 First, save the default configuration to a new file:
@@ -209,9 +210,10 @@ layout: [flags, " ", branch]
 
 This is the list of additional configuration `options`:
 
-| Option           | Description                                                | Default        |
-| :--------------- | :--------------------------------------------------------- | :------------- |
-| `branch_max_len` | Maximum displayed length for local and remote branch names | `0` (no limit) |
+| Option           | Description                                                | Default            |
+| :--------------- | :--------------------------------------------------------- | :----------------- |
+| `branch_max_len` | Maximum displayed length for local and remote branch names | `0` (no limit)     |
+| `branch_trim`    | Trim left or right end of the branch (`right` or `left`)   | `right` (trailing) |
 
 
 ## Troubleshooting

--- a/gitmux.go
+++ b/gitmux.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/arl/gitstatus"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 
 	"github.com/arl/gitmux/json"
 	"github.com/arl/gitmux/tmux"

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.15
 
 require (
 	github.com/arl/gitstatus v0.4.3
-	github.com/stretchr/testify v1.7.0
+	github.com/stretchr/testify v1.7.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,5 @@ go 1.15
 require (
 	github.com/arl/gitstatus v0.4.3
 	github.com/stretchr/testify v1.7.0
-	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )

--- a/go.sum
+++ b/go.sum
@@ -10,7 +10,6 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
-gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
+gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/tmux/formater.go
+++ b/tmux/formater.go
@@ -197,7 +197,8 @@ func (f *Formater) format() {
 		case "branch":
 			f.specialState()
 		case "remote":
-			f.remote()
+			f.remoteBranch()
+			f.divergence()
 		case "remote-branch":
 			f.remoteBranch()
 		case "divergence":
@@ -236,7 +237,7 @@ func (f *Formater) specialState() {
 	f.currentRef()
 }
 
-func (f *Formater) remote() {
+func (f *Formater) remoteBranch() {
 	if f.st.RemoteBranch == "" {
 		return
 	}
@@ -245,18 +246,6 @@ func (f *Formater) remote() {
 
 	branch := truncateBranchName(f.st.RemoteBranch, f.Options.BranchMaxLen, true, f.Options.BranchTrimDirection)
 	fmt.Fprintf(&f.b, "%s%s", f.Styles.Remote, branch)
-
-	f.divergence()
-}
-
-func (f *Formater) remoteBranch() {
-	if f.st.RemoteBranch != "" {
-		f.clear()
-
-		branch := truncateBranchName(f.st.RemoteBranch, f.Options.BranchMaxLen, true, f.Options.BranchTrimDirection)
-		fmt.Fprintf(&f.b, "%s%s", f.Styles.Remote, branch)
-
-	}
 }
 
 func (f *Formater) divergence() {

--- a/tmux/formater.go
+++ b/tmux/formater.go
@@ -77,8 +77,8 @@ func (d *direction) UnmarshalYAML(value *yaml.Node) error {
 }
 
 type options struct {
-	BranchMaxLen        int       `yaml:"branch_max_len"`
-	BranchTrimDirection direction `yaml:"branch_trim_direction"`
+	BranchMaxLen int       `yaml:"branch_max_len"`
+	BranchTrim   direction `yaml:"branch_trim"`
 }
 
 // DefaultCfg is the default tmux configuration.
@@ -110,8 +110,8 @@ var DefaultCfg = Config{
 	},
 	Layout: []string{"branch", "..", "remote-branch", "divergence", " - ", "flags"},
 	Options: options{
-		BranchMaxLen:        0,
-		BranchTrimDirection: dirRight,
+		BranchMaxLen: 0,
+		BranchTrim:   dirRight,
 	},
 }
 
@@ -162,7 +162,7 @@ func (f *Formater) Format(w io.Writer, st *gitstatus.Status) error {
 
 	// overall working tree state
 	if f.st.IsInitial {
-		branch := truncate(f.st.LocalBranch, f.Options.BranchMaxLen, f.Options.BranchTrimDirection)
+		branch := truncate(f.st.LocalBranch, f.Options.BranchMaxLen, f.Options.BranchTrim)
 		fmt.Fprintf(w, "%s%s [no commits yet]", f.Styles.Branch, branch)
 		f.flags()
 		_, err := f.b.WriteTo(w)
@@ -229,7 +229,7 @@ func (f *Formater) remoteBranch() {
 
 	f.clear()
 
-	branch := truncate(f.st.RemoteBranch, f.Options.BranchMaxLen, f.Options.BranchTrimDirection)
+	branch := truncate(f.st.RemoteBranch, f.Options.BranchMaxLen, f.Options.BranchTrim)
 	fmt.Fprintf(&f.b, "%s%s", f.Styles.Remote, branch)
 }
 
@@ -264,7 +264,7 @@ func (f *Formater) currentRef() {
 		return
 	}
 
-	branch := truncate(f.st.LocalBranch, f.Options.BranchMaxLen, f.Options.BranchTrimDirection)
+	branch := truncate(f.st.LocalBranch, f.Options.BranchMaxLen, f.Options.BranchTrim)
 	fmt.Fprintf(&f.b, "%s%s", f.Styles.Branch, branch)
 }
 

--- a/tmux/formater_test.go
+++ b/tmux/formater_test.go
@@ -427,8 +427,8 @@ func TestFormat(t *testing.T) {
 			},
 			layout: []string{"branch", " ", "remote"},
 			options: options{
-				BranchMaxLen:        9,
-				BranchTrimDirection: dirRight,
+				BranchMaxLen: 9,
+				BranchTrim:   dirRight,
 			},
 			st: &gitstatus.Status{
 				Porcelain: gitstatus.Porcelain{
@@ -453,8 +453,8 @@ func TestFormat(t *testing.T) {
 			},
 			layout: []string{"branch", " ", "remote"},
 			options: options{
-				BranchMaxLen:        9,
-				BranchTrimDirection: dirLeft,
+				BranchMaxLen: 9,
+				BranchTrim:   dirLeft,
 			},
 			st: &gitstatus.Status{
 				Porcelain: gitstatus.Porcelain{

--- a/tmux/formater_test.go
+++ b/tmux/formater_test.go
@@ -185,6 +185,7 @@ func TestTruncateBranchName(t *testing.T) {
 		branchName string
 		maxLen     int
 		isRemote   bool
+		dir        direction
 		want       string
 	}{
 		{
@@ -192,6 +193,7 @@ func TestTruncateBranchName(t *testing.T) {
 			branchName: "foo/bar-baz",
 			maxLen:     0,
 			isRemote:   false,
+			dir:        dirRight,
 			want:       "foo/bar-baz",
 		},
 		{
@@ -199,6 +201,7 @@ func TestTruncateBranchName(t *testing.T) {
 			branchName: "foo/bar-baz",
 			maxLen:     11,
 			isRemote:   false,
+			dir:        dirRight,
 			want:       "foo/bar-baz",
 		},
 		{
@@ -206,6 +209,7 @@ func TestTruncateBranchName(t *testing.T) {
 			branchName: "foo/bar-baz",
 			maxLen:     10,
 			isRemote:   false,
+			dir:        dirRight,
 			want:       "foo/bar...",
 		},
 		{
@@ -213,6 +217,7 @@ func TestTruncateBranchName(t *testing.T) {
 			branchName: "remote/foo/bar-baz",
 			maxLen:     10,
 			isRemote:   true,
+			dir:        dirRight,
 			want:       "remote/foo/bar...",
 		},
 		{
@@ -220,6 +225,7 @@ func TestTruncateBranchName(t *testing.T) {
 			branchName: "foo/bar-baz",
 			maxLen:     1,
 			isRemote:   false,
+			dir:        dirRight,
 			want:       ".",
 		},
 		{
@@ -227,13 +233,14 @@ func TestTruncateBranchName(t *testing.T) {
 			branchName: "foo/测试这个名字",
 			maxLen:     9,
 			isRemote:   false,
+			dir:        dirRight,
 			want:       "foo/测试...",
 		},
 	}
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			branchName := truncateBranchName(tc.branchName, tc.maxLen, tc.isRemote)
+			branchName := truncateBranchName(tc.branchName, tc.maxLen, tc.isRemote, tc.dir)
 			require.EqualValues(t, tc.want, branchName)
 		})
 	}
@@ -359,7 +366,34 @@ func TestFormat(t *testing.T) {
 			},
 			layout: []string{"branch", " ", "remote"},
 			options: options{
-				BranchMaxLen: 9,
+				BranchMaxLen:        9,
+				BranchTrimDirection: dirRight,
+			},
+			st: &gitstatus.Status{
+				Porcelain: gitstatus.Porcelain{
+					LocalBranch:  "branchName",
+					RemoteBranch: "remote/branchName",
+				},
+			},
+			want: "StyleClear" + "StyleBranch" + "SymbolBranch" +
+				"StyleClear" + "StyleBranch" + "branch..." +
+				"StyleClear" + " " +
+				"StyleClear" + "StyleRemote" + "remote/branch...",
+		},
+		{
+			name: "branch and remote, branch_max_len not zero and branch_trim_direction left",
+			styles: styles{
+				Clear:  "StyleClear",
+				Branch: "StyleBranch",
+				Remote: "StyleRemote",
+			},
+			symbols: symbols{
+				Branch: "SymbolBranch",
+			},
+			layout: []string{"branch", " ", "remote"},
+			options: options{
+				BranchMaxLen:        9,
+				BranchTrimDirection: dirLeft,
 			},
 			st: &gitstatus.Status{
 				Porcelain: gitstatus.Porcelain{

--- a/tmux/formater_test.go
+++ b/tmux/formater_test.go
@@ -1,7 +1,7 @@
 package tmux
 
 import (
-	"os"
+	"io"
 	"testing"
 
 	"github.com/arl/gitstatus"
@@ -494,7 +494,7 @@ func TestFormat(t *testing.T) {
 				Config: Config{Styles: tt.styles, Symbols: tt.symbols, Layout: tt.layout, Options: tt.options},
 			}
 
-			if err := f.Format(os.Stdout, tt.st); err != nil {
+			if err := f.Format(io.Discard, tt.st); err != nil {
 				t.Fatalf("Format error: %s", err)
 			}
 

--- a/tmux/formater_test.go
+++ b/tmux/formater_test.go
@@ -4,8 +4,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/arl/gitstatus"
 )
 
@@ -76,15 +74,17 @@ func TestFlags(t *testing.T) {
 			want: "StyleClear" + "StyleConflictSymbolConflict42 StyleUntrackedSymbolUntracked17",
 		},
 	}
-	for _, tc := range tests {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 			f := &Formater{
-				Config: Config{Styles: tc.styles, Symbols: tc.symbols, Layout: tc.layout},
-				st:     tc.st,
+				Config: Config{Styles: tt.styles, Symbols: tt.symbols, Layout: tt.layout},
+				st:     tt.st,
 			}
 			f.flags()
-			require.EqualValues(t, tc.want, f.b.String())
+
+			if got := f.b.String(); got != tt.want {
+				t.Errorf("got:\n%s\n\nwant:\n%s\n", got, tt.want)
+			}
 		})
 	}
 }
@@ -166,15 +166,17 @@ func TestDivergence(t *testing.T) {
 			want: "StyleClear" + " ↑·128↓·41",
 		},
 	}
-	for _, tc := range tests {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 			f := &Formater{
-				Config: Config{Styles: tc.styles, Symbols: tc.symbols},
-				st:     tc.st,
+				Config: Config{Styles: tt.styles, Symbols: tt.symbols},
+				st:     tt.st,
 			}
 			f.divergence()
-			require.EqualValues(t, tc.want, f.b.String())
+
+			if got := f.b.String(); got != tt.want {
+				t.Errorf("got:\n%s\n\nwant:\n%s\n", got, tt.want)
+			}
 		})
 	}
 }
@@ -486,19 +488,20 @@ func TestFormat(t *testing.T) {
 				"StyleClear" + "StyleBranch" + "branchName",
 		},
 	}
-	for _, tc := range tests {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 			f := &Formater{
-				Config: Config{Styles: tc.styles, Symbols: tc.symbols, Layout: tc.layout, Options: tc.options},
+				Config: Config{Styles: tt.styles, Symbols: tt.symbols, Layout: tt.layout, Options: tt.options},
 			}
 
-			if err := f.Format(os.Stdout, tc.st); err != nil {
+			if err := f.Format(os.Stdout, tt.st); err != nil {
 				t.Fatalf("Format error: %s", err)
 			}
 
 			f.format()
-			require.EqualValues(t, tc.want, f.b.String())
+			if got := f.b.String(); got != tt.want {
+				t.Errorf("got:\n%s\n\nwant:\n%s\n", got, tt.want)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Add a `branch_trim` option (defaults to `right` so backward compatible). Accepts `right` or `left`, which indicates the position where the branch (and remote) names are trimmed if they're shorted than `branch_max_len`.

Closes #58  