### PR TITLE
go.mod: upgrade to gitstatus@v0.4.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/arl/gitmux
 go 1.15
 
 require (
-	github.com/arl/gitstatus v0.4.3
+	github.com/arl/gitstatus v0.4.4
 	github.com/stretchr/testify v1.7.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/arl/gitstatus v0.4.3 h1:ad4Fk4uXRy7WRvK6UMKD1ijvElFN/ugvqzDWJo00pJs=
-github.com/arl/gitstatus v0.4.3/go.mod h1:pEiL+vLLz99X0m5G4MySAt4o0fQw2yUbFeq2s7sMUzY=
+github.com/arl/gitstatus v0.4.4 h1:de5hty3GKMgiilxPzoE5w8Y+PSK6d8Cb7MReH61+zKQ=
+github.com/arl/gitstatus v0.4.4/go.mod h1:pEiL+vLLz99X0m5G4MySAt4o0fQw2yUbFeq2s7sMUzY=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
Update to gitstatus@v0.4.4 in which the bug with files with staged hunks has been fixed.

Closes #61