### PR TITLE
Decouple stash entries from clean flag

### DIFF
--- a/tmux/formater.go
+++ b/tmux/formater.go
@@ -269,14 +269,18 @@ func (f *Formater) currentRef() {
 }
 
 func (f *Formater) flags() {
+	var flags []string
 	if f.st.IsClean {
-		f.clear()
-		fmt.Fprintf(&f.b, "%s%s", f.Styles.Clean, f.Symbols.Clean)
+		if f.st.NumStashed != 0 {
+			flags = append(flags,
+				fmt.Sprintf("%s%s%d", f.Styles.Stashed, f.Symbols.Stashed, f.st.NumStashed))
+		}
 
+		flags = append(flags, fmt.Sprintf("%s%s", f.Styles.Clean, f.Symbols.Clean))
+		f.clear()
+		f.b.WriteString(strings.Join(flags, " "))
 		return
 	}
-
-	var flags []string
 
 	if f.st.NumStaged != 0 {
 		flags = append(flags,

--- a/tmux/formater_test.go
+++ b/tmux/formater_test.go
@@ -32,6 +32,24 @@ func TestFlags(t *testing.T) {
 			want: "StyleClear" + "StyleCleanSymbolClean",
 		},
 		{
+			name: "stash + clean flag",
+			styles: styles{
+				Clear:   "StyleClear",
+				Clean:   "StyleClean",
+				Stashed: "StyleStash",
+			},
+			symbols: symbols{
+				Clean:   "SymbolClean",
+				Stashed: "SymbolStash",
+			},
+			layout: []string{"branch", "..", "remote", " - ", "flags"},
+			st: &gitstatus.Status{
+				IsClean:    true,
+				NumStashed: 1,
+			},
+			want: "StyleClearStyleStashSymbolStash1 StyleCleanSymbolClean",
+		},
+		{
 			name: "mixed flags",
 			styles: styles{
 				Clear:    "StyleClear",


### PR DESCRIPTION
Since now the clean flag is indepdendent from the number of
stashed entries, we need to show the stash count, even if the
working tree is clean.

Fix #66