### PR TITLE
Update README for installing with Go

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,12 @@ Works with all decently recent [tmux](https://github.com/tmux/tmux) versions.
 ### From source
 
 [Download and install a Go compiler](https://golang.org/dl/) (Go 1.15 or later).
-Run `go get` to build and install `gitmux`:
+Run `go get` or `go install` depending on what version you pick to build and install `gitmux`:
 
-    go get -u github.com/arl/gitmux
+```bash
+go install github.com/arl/gitmux@latest # on go 1.17+
+go get -u github.com/arl/gitmux         # on go 1.16 and below
+```
 
 ## Getting started
 


### PR DESCRIPTION
On Go 1.17, `go get -u` as a method os installation locally was deprecated, and on 1.18 it completely fails to run. Switching to `go install github.com/arl/gitmux@latest` works as expected on 1.17+.

## Purpose

To make the README slightly more accurate depending on what version you have chosen.

## Approach

Clearly denotes what command to use depending on what version of Go you decide to use.