### PR TITLE
goreleaser: add license+readme to archives

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,7 +18,8 @@ archives:
   - replacements:
       darwin: macOS
     files:
-      - none*
+      - LICENSE
+      - README.md
 checksum:
   name_template: "checksums.txt"
 snapshot:


### PR DESCRIPTION
Fixes #71

## Purpose

Add LICENSE and README.md to released archives created by goreleaser
