### PR TITLE
Added AUR packages installation info to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,12 @@ Works with all decently recent [tmux](https://github.com/tmux/tmux) versions.
 ## Installing
 
 ### Binary release
+
 [Download the latest](https://github.com/arl/gitmux/releases/latest) binary for your platform/architecture and uncompress it.
+
+### AUR
+
+Arch Linux users can download the [gitmux](https://aur.archlinux.org/packages/gitmux), [gitmux-bin](https://aur.archlinux.org/packages/gitmux-bin) or [gitmux-git](https://aur.archlinux.org/packages/gitmux-git) AUR package.
 
 ### From source
 


### PR DESCRIPTION
Added the AUR packages installation information to the README

## Purpose
The idea of putting the AUR packages installation information to the README has been discussed in #71 

## Approach
Adding the said information :)

*By the way, I wanted to mention that I'm only the maintainer of the [gitmux-bin](https://aur.archlinux.org/packages/gitmux-bin) AUR package as of now.*  
*The [gitmux](https://aur.archlinux.org/packages/gitmux) and [gitmux-git](https://aur.archlinux.org/packages/gitmux-git) AUR packages are maintained by other users currently, but I'm down to adopt them if I have the opportunity in a potential future (for instance if the current maintainers have no time or lost interest in maintaining those packages).*
