### PR TITLE
Brew tap

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -25,6 +25,6 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   goreleaser:
+    name: Publish release to github/brew
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -28,3 +29,17 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+
+  check_brew:
+    name: Check brew tap has been updated
+    runs-on: macos-latest
+    needs: goreleaser
+    steps:
+      - name: brew tap/install
+        run: |
+          brew tap arl/arl
+          brew install gitmux
+          gitmux -V
+      - name: check gitmux version
+        run: |
+          [ v$(gitmux -V) == "$GITHUB_REF_NAME" ]

--- a/README.md
+++ b/README.md
@@ -5,8 +5,12 @@
 <hr>
 
 <p align="center">
-<a href="https://github.com/arl/gitmux/actions">
-  <img alt="tests" src="https://github.com/arl/gitmux/actions/workflows/tests.yml/badge.svg" />
+
+<a href="https://github.com/arl/gitmux/actions/workflows/ci.yml">
+  <img alt="tests" src="https://github.com/arl/gitmux/actions/workflows/ci.yml/badge.svg" />
+</a>
+<a href="https://github.com/arl/gitmux/actions/workflows/cd.yml">
+  <img alt="tests" src="https://github.com/arl/gitmux/actions/workflows/cd.yml/badge.svg" />
 </a>
 <a href="https://goreportcard.com/report/github.com/arl/gitmux">
   <img alt="goreport" src="https://goreportcard.com/badge/github.com/arl/gitmux" />
@@ -24,6 +28,7 @@
  - **discrete**. Get out of your way if current directory is not in a Git tree
  - **shell-agnostic**. Does not rely on shell-features so works with all of them
  - **customizable**. Colors, symbols and layout are configurable
+
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,16 @@ Works with all decently recent [tmux](https://github.com/tmux/tmux) versions.
 
 [Download the latest](https://github.com/arl/gitmux/releases/latest) binary for your platform/architecture and uncompress it.
 
+
+### Homebrew (tap)
+
+Install the latest version with:
+
+```sh
+brew tap arl/arl
+brew install gitmux
+```
+
 ### AUR
 
 Arch Linux users can download the [gitmux](https://aur.archlinux.org/packages/gitmux), [gitmux-bin](https://aur.archlinux.org/packages/gitmux-bin) or [gitmux-git](https://aur.archlinux.org/packages/gitmux-git) AUR package.


### PR DESCRIPTION
Since the arl/arl brew tap is up and running and gitmux can be installed from it, update the README.md with install information for brew users 🎉 
