### PR TITLE
Issue 60/ellipsis

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ tmux:
     options:
         branch_max_len: 0
         branch_trim: right
+        ellipsis: …
 ```
 
 First, save the default configuration to a new file:
@@ -261,10 +262,11 @@ layout: [branch, "|", flags, "|", stats]
 
 This is the list of additional configuration `options`:
 
-| Option           | Description                                                | Default            |
-| :--------------- | :--------------------------------------------------------- | :----------------- |
-| `branch_max_len` | Maximum displayed length for local and remote branch names | `0` (no limit)     |
+| Option           | Description                                                |      Default       |
+| :--------------- | :--------------------------------------------------------- | :----------------: |
+| `branch_max_len` | Maximum displayed length for local and remote branch names |   `0` (no limit)   |
 | `branch_trim`    | Trim left or right end of the branch (`right` or `left`)   | `right` (trailing) |
+| `ellipsis`       | Character to show branch name has been truncated           |        `…`         |
 
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 - [Prerequisites](#prerequisites)
 - [Installing](#installing)
   - [Binary release](#binary-release)
-  - [Homebrew (tap) macOS and linux, amd64 and arm64](#homebrew-tap-macos-and-linux-amd64-and-arm64)
+  - [Homebrew tap (macOS and linux) (amd64 and arm64)](#homebrew-tap-macos-and-linux-amd64-and-arm64)
   - [AUR](#aur)
   - [From source](#from-source)
 - [Getting started](#getting-started)

--- a/testdata/default.output.txt
+++ b/testdata/default.output.txt
@@ -51,4 +51,4 @@ with some different content
 
 -- empty_file --
 -- output.golden --
-#[fg=default]#[fg=default]#[fg=white,bold]⎇ #[fg=default]#[fg=white,bold]main#[fg=default]..#[fg=default] - #[fg=default]#[fg=green,bold]● 1 #[fg=red,bold]✚ 1 #[fg=cyan,bold]⚑ 1 #[fg=magenta,bold]… 2
+#[fg=default]#[fg=default]#[fg=white,bold]⎇ #[fg=default]#[fg=white,bold]main#[fg=default] #[fg=default] - #[fg=default]#[fg=green,bold]● 1 #[fg=red,bold]✚ 1 #[fg=cyan,bold]⚑ 1 #[fg=magenta,bold]… 2

--- a/tmux/formater.go
+++ b/tmux/formater.go
@@ -122,7 +122,7 @@ var DefaultCfg = Config{
 		Insertions: "#[fg=green]",
 		Deletions:  "#[fg=red]",
 	},
-	Layout: []string{"branch", "..", "remote-branch", "divergence", " - ", "flags"},
+	Layout: []string{"branch", " ", "remote-branch", "divergence", " - ", "flags"},
 	Options: options{
 		BranchMaxLen: 0,
 		BranchTrim:   dirRight,

--- a/tmux/formater_test.go
+++ b/tmux/formater_test.go
@@ -485,10 +485,11 @@ func TestFormat(t *testing.T) {
 			symbols: symbols{
 				Branch: "SymbolBranch",
 			},
-			layout: []string{"branch", " ", "remote"},
+			layout: []string{"branch", "/", "remote"},
 			options: options{
 				BranchMaxLen: 9,
 				BranchTrim:   dirRight,
+				Ellipsis:     `…`,
 			},
 			st: &gitstatus.Status{
 				Porcelain: gitstatus.Porcelain{
@@ -497,9 +498,9 @@ func TestFormat(t *testing.T) {
 				},
 			},
 			want: "StyleClear" + "StyleBranch" + "SymbolBranch" +
-				"StyleClear" + "StyleBranch" + "branch..." +
-				"StyleClear" + " " +
-				"StyleClear" + "StyleRemote" + "remote...",
+				"StyleClear" + "StyleBranch" + "branchNa…" +
+				"StyleClear" + "/" +
+				"StyleClear" + "StyleRemote" + "remote/b…",
 		},
 		{
 			name: "branch and remote, branch_max_len not zero and trim left",
@@ -515,6 +516,7 @@ func TestFormat(t *testing.T) {
 			options: options{
 				BranchMaxLen: 9,
 				BranchTrim:   dirLeft,
+				Ellipsis:     "...",
 			},
 			st: &gitstatus.Status{
 				Porcelain: gitstatus.Porcelain{
@@ -554,6 +556,7 @@ func TestFormat(t *testing.T) {
 
 			if err := f.Format(io.Discard, tt.st); err != nil {
 				t.Fatalf("Format error: %s", err)
+				return
 			}
 
 			f.format()

--- a/tmux/formater_test.go
+++ b/tmux/formater_test.go
@@ -199,128 +199,168 @@ func TestDivergence(t *testing.T) {
 	}
 }
 
-func TestTruncate(t *testing.T) {
+func Test_truncate(t *testing.T) {
 	tests := []struct {
-		s    string
-		max  int
-		dir  direction
-		want string
+		s        string
+		max      int
+		ellipsis string
+		dir      direction
+		want     string
 	}{
 		/* trim right */
 		{
-			s:    "br",
-			max:  1,
-			dir:  dirRight,
-			want: "b",
+			s:        "br",
+			ellipsis: "...",
+			max:      1,
+			dir:      dirRight,
+			want:     "b",
 		},
 		{
-			s:    "br",
-			max:  3,
-			dir:  dirRight,
-			want: "br",
+			s:        "br",
+			ellipsis: "...",
+			max:      3,
+			dir:      dirRight,
+			want:     "br",
 		},
 		{
-			s:    "super-long-branch",
-			max:  3,
-			dir:  dirRight,
-			want: "...",
+			s:        "super-long-branch",
+			ellipsis: "...",
+			max:      3,
+			dir:      dirRight,
+			want:     "...",
 		},
 		{
-			s:    "super-long-branch",
-			max:  15,
-			dir:  dirRight,
-			want: "super-long-b...",
+			s:        "super-long-branch",
+			ellipsis: "...",
+			max:      15,
+			dir:      dirRight,
+			want:     "super-long-b...",
 		},
 		{
-			s:    "super-long-branch",
-			max:  17,
-			dir:  dirRight,
-			want: "super-long-branch",
+			s:        "super-long-branch",
+			ellipsis: "...",
+			max:      17,
+			dir:      dirRight,
+			want:     "super-long-branch",
 		},
 		{
-			s:    "长長的-树樹枝",
-			max:  6,
-			dir:  dirRight,
-			want: "长長的...",
+			s:        "super-long-branch",
+			ellipsis: "…",
+			max:      17,
+			dir:      dirRight,
+			want:     "super-long-branch",
 		},
 		{
-			s:    "super-long-branch",
-			max:  32,
-			dir:  dirRight,
-			want: "super-long-branch",
+			s:        "super-long-branch",
+			ellipsis: "…",
+			max:      15,
+			dir:      dirRight,
+			want:     "super-long-bra…",
 		},
 		{
-			s:    "super-long-branch",
-			max:  0,
-			dir:  dirRight,
-			want: "super-long-branch",
+			s:        "长長的-树樹枝",
+			ellipsis: "...",
+			max:      6,
+			dir:      dirRight,
+			want:     "长長的...",
 		},
 		{
-			s:    "super-long-branch",
-			max:  -1,
-			dir:  dirRight,
-			want: "super-long-branch",
+			s:        "super-long-branch",
+			ellipsis: "...",
+			max:      32,
+			dir:      dirRight,
+			want:     "super-long-branch",
+		},
+		{
+			s:        "super-long-branch",
+			ellipsis: "...",
+			max:      0,
+			dir:      dirRight,
+			want:     "super-long-branch",
+		},
+		{
+			s:        "super-long-branch",
+			ellipsis: "...",
+			max:      -1,
+			dir:      dirRight,
+			want:     "super-long-branch",
 		},
 
 		/* trim left */
 		{
-			s:    "br",
-			max:  1,
-			dir:  dirLeft,
-			want: "r",
+			s:        "br",
+			ellipsis: "...",
+			max:      1,
+			dir:      dirLeft,
+			want:     "r",
 		},
 		{
-			s:    "br",
-			max:  3,
-			dir:  dirLeft,
-			want: "br",
+			s:        "br",
+			ellipsis: "",
+			max:      1,
+			dir:      dirLeft,
+			want:     "r",
 		},
 		{
-			s:    "super-long-branch",
-			max:  3,
-			dir:  dirLeft,
-			want: "...",
+			s:        "br",
+			ellipsis: "...",
+			max:      3,
+			dir:      dirLeft,
+			want:     "br",
 		},
 		{
-			s:    "super-long-branch",
-			max:  15,
-			dir:  dirLeft,
-			want: "...-long-branch",
+			s:        "super-long-branch",
+			ellipsis: "...",
+			max:      3,
+			dir:      dirLeft,
+			want:     "...",
 		},
 		{
-			s:    "super-long-branch",
-			max:  17,
-			dir:  dirLeft,
-			want: "super-long-branch",
+			s:        "super-long-branch",
+			ellipsis: "...",
+			max:      15,
+			dir:      dirLeft,
+			want:     "...-long-branch",
 		},
 		{
-			s:    "长長的-树樹枝",
-			max:  6,
-			dir:  dirLeft,
-			want: "...树樹枝",
+			s:        "super-long-branch",
+			ellipsis: "...",
+			max:      17,
+			dir:      dirLeft,
+			want:     "super-long-branch",
 		},
 		{
-			s:    "super-long-branch",
-			max:  32,
-			dir:  dirLeft,
-			want: "super-long-branch",
+			s:        "长長的-树樹枝",
+			ellipsis: "...",
+			max:      6,
+			dir:      dirLeft,
+			want:     "...树樹枝",
 		},
 		{
-			s:    "super-long-branch",
-			max:  0,
-			dir:  dirLeft,
-			want: "super-long-branch",
+			s:        "super-long-branch",
+			ellipsis: "...",
+			max:      32,
+			dir:      dirLeft,
+			want:     "super-long-branch",
 		},
 		{
-			s:    "super-long-branch",
-			max:  -1,
-			dir:  dirLeft,
-			want: "super-long-branch",
+			s:        "super-long-branch",
+			ellipsis: "...",
+			max:      0,
+			dir:      dirLeft,
+			want:     "super-long-branch",
+		},
+		{
+			s:        "super-long-branch",
+			ellipsis: "...",
+			max:      -1,
+			dir:      dirLeft,
+			want:     "super-long-branch",
 		},
 	}
 	for _, tt := range tests {
 		t.Run("", func(t *testing.T) {
-			if got := truncate(tt.s, tt.max, tt.dir); got != tt.want {
+			if got := truncate(tt.s, tt.ellipsis, tt.max, tt.dir); got != tt.want {
 				t.Errorf("truncate(%q, %d, %s) = %q, want %q", tt.s, tt.max, tt.dir, got, tt.want)
 			}
 		})


### PR DESCRIPTION
## Purpose

- Make configurable the ellipsis character used when branch or remote are truncated.
- Change the default to `…` rather than `...`. It's smaller and much nicer.
This should be ok with the majority of fonts but we make this configurable in case.

- Also replace, in `layout` the `..` separator between branch and remote. When `…`was added, the difference between the thin dots in `…` and the big ones in `..` was ugly.