### PR TITLE
feat: adds option to hide clean flag

### DIFF
--- a/.gitmux.yml
+++ b/.gitmux.yml
@@ -79,3 +79,5 @@ tmux:
         branch_trim: right
         # Character indicating whether and where a branch was truncated.
         ellipsis: …
+        # Hides the clean flag
+        hide_clean: false

--- a/tmux/formater.go
+++ b/tmux/formater.go
@@ -89,6 +89,7 @@ type options struct {
 	BranchMaxLen int       `yaml:"branch_max_len"`
 	BranchTrim   direction `yaml:"branch_trim"`
 	Ellipsis     string    `yaml:"ellipsis"`
+	HideClean    bool      `yaml:"hide_clean"`
 }
 
 // A Formater formats git status to a tmux style string.
@@ -256,7 +257,10 @@ func (f *Formater) flags() {
 				fmt.Sprintf("%s%s%d", f.Styles.Stashed, f.Symbols.Stashed, f.st.NumStashed))
 		}
 
-		flags = append(flags, fmt.Sprintf("%s%s", f.Styles.Clean, f.Symbols.Clean))
+		if f.Options.HideClean != true {
+			flags = append(flags, fmt.Sprintf("%s%s", f.Styles.Clean, f.Symbols.Clean))
+		}
+
 		f.clear()
 		f.b.WriteString(strings.Join(flags, " "))
 		return


### PR DESCRIPTION
## Purpose

Adds the option for a user to hide the clean flag. I, personally, would rather not see anything as an indicator that everything is clean.

## Approach

Add a `hide_clean` option that defaults to `false` and when set to `true` will not render the clean flag.
