### PR TITLE
fix: only render if hideClean is false and there are stashes

### DIFF
--- a/tmux/formater.go
+++ b/tmux/formater.go
@@ -267,7 +267,9 @@ func (f *Formater) flags() string {
 			flags = append(flags, fmt.Sprintf("%s%s", f.Styles.Clean, f.Symbols.Clean))
 		}
 
-		return f.Styles.Clear + strings.Join(flags, " ")
+		if len(flags) != 0 {
+			return f.Styles.Clear + strings.Join(flags, " ")
+		}
 	}
 
 	if f.st.NumStaged != 0 {


### PR DESCRIPTION
## Purpose

When `HideClean` is enable, a component would still get rendered because of the clear fix join.

## Approach

Check if the stash or clean components have been defined before cleaning and joining them.
