### PR TITLE
Trailing space

### DIFF
--- a/.gitmux.yml
+++ b/.gitmux.yml
@@ -79,5 +79,5 @@ tmux:
         branch_trim: right
         # Character indicating whether and where a branch was truncated.
         ellipsis: …
-        # Hides the clean flag
+        # Hides the clean flag.
         hide_clean: false

--- a/.gitmux.yml
+++ b/.gitmux.yml
@@ -81,3 +81,5 @@ tmux:
         ellipsis: …
         # Hides the clean flag.
         hide_clean: false
+        # Adds a trailing space to the layout.
+        trailing_space: false

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ tmux:
         branch_trim: right
         ellipsis: …
         hide_clean: false
+        trailing_space: false
 ```
 
 First, save the default configuration to a new file:
@@ -271,6 +272,7 @@ This is the list of additional configuration `options`:
 | `branch_trim`    | Trim left or right end of the branch (`right` or `left`)   | `right` (trailing) |
 | `ellipsis`       | Character to show branch name has been truncated           |        `…`         |
 | `hide_clean`     | Hides the clean flag entirely                              |      `false`       |
+| `trailing_space` | Adds a trailing space to the layout                        |      `false`       |
 
 
 ## Troubleshooting

--- a/tmux/formater.go
+++ b/tmux/formater.go
@@ -85,10 +85,11 @@ func (d *direction) UnmarshalYAML(value *yaml.Node) error {
 }
 
 type options struct {
-	BranchMaxLen int       `yaml:"branch_max_len"`
-	BranchTrim   direction `yaml:"branch_trim"`
-	Ellipsis     string    `yaml:"ellipsis"`
-	HideClean    bool      `yaml:"hide_clean"`
+	BranchMaxLen  int       `yaml:"branch_max_len"`
+	BranchTrim    direction `yaml:"branch_trim"`
+	Ellipsis      string    `yaml:"ellipsis"`
+	HideClean     bool      `yaml:"hide_clean"`
+	TrailingSpace bool      `yaml:"trailing_space"`
 }
 
 // A Formater formats git status to a tmux style string.
@@ -160,7 +161,14 @@ func (f *Formater) format() string {
 				i++
 			}
 		}
-		return strings.Join(comps[:i], " ")
+
+		var output = strings.Join(comps[:i], " ")
+
+		if f.Options.TrailingSpace {
+			output += " "
+		}
+
+		return output
 	}
 
 	sb := strings.Builder{}

--- a/tmux/formater_test.go
+++ b/tmux/formater_test.go
@@ -539,6 +539,42 @@ func TestFormat(t *testing.T) {
 				"StyleClear" + "StyleBranch" + "branchName",
 		},
 		{
+			name: "trailing space option false",
+			styles: styles{
+				Clear: "StyleClear",
+				Clean: "StyleClean",
+			},
+			symbols: symbols{
+				Clean: "SymbolClean",
+			},
+			layout: []string{"flags"},
+			st: &gitstatus.Status{
+				IsClean: true,
+			},
+			options: options{
+				TrailingSpace: false,
+			},
+			want: "StyleClear" + "StyleCleanSymbolClean",
+		},
+		{
+			name: "trailing space option true",
+			styles: styles{
+				Clear: "StyleClear",
+				Clean: "StyleClean",
+			},
+			symbols: symbols{
+				Clean: "SymbolClean",
+			},
+			layout: []string{"flags"},
+			st: &gitstatus.Status{
+				IsClean: true,
+			},
+			options: options{
+				TrailingSpace: true,
+			},
+			want: "StyleClear" + "StyleCleanSymbolClean ",
+		},
+		{
 			name: "hide clean option true",
 			styles: styles{
 				Clear: "StyleClear",


### PR DESCRIPTION
## Purpose

As a user, I want to render gitmux between other elements on my tmux status bar. I need a space between the elements but I don't want any unnecessary spaces if gitmux doesn't return anything leaving the tmux prompt pixel-perfect.

## Approach

- Add a `trailing_space` option to gitmux (default to `false`)
- Render a trailing space to the layout when the option is true.
