### PR TITLE
Adding swap_divergence flag

### DIFF
--- a/.gitmux.yml
+++ b/.gitmux.yml
@@ -81,3 +81,5 @@ tmux:
         ellipsis: …
         # Hides the clean flag
         hide_clean: false
+        # Swaps order of behind & ahead upstream counts - "↓·1↑·1" -> "↑·1↓·1"
+        swap_divergence: false

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ tmux:
         branch_trim: right
         ellipsis: …
         hide_clean: false
+        swap_divergence: false
 ```
 
 First, save the default configuration to a new file:
@@ -269,6 +270,7 @@ This is the list of additional configuration `options`:
 | `branch_trim`    | Trim left or right end of the branch (`right` or `left`)   | `right` (trailing) |
 | `ellipsis`       | Character to show branch name has been truncated           |        `…`         |
 | `hide_clean`     | Hides the clean flag entirely                              |      `false`       |
+| `swap_divergence`| Swaps behind & ahead upstream counts' order                |      `false`       |
 
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ This is the list of additional configuration `options`:
 | `branch_trim`    | Trim left or right end of the branch (`right` or `left`)   | `right` (trailing) |
 | `ellipsis`       | Character to show branch name has been truncated           |        `…`         |
 | `hide_clean`     | Hides the clean flag entirely                              |      `false`       |
-| `swap_divergence`| Swaps behind & ahead upstream counts' order                |      `false`       |
+| `swap_divergence`| Swaps order of behind & ahead upstream counts              |      `false`       |
 
 
 ## Troubleshooting

--- a/tmux/formater.go
+++ b/tmux/formater.go
@@ -85,10 +85,11 @@ func (d *direction) UnmarshalYAML(value *yaml.Node) error {
 }
 
 type options struct {
-	BranchMaxLen int       `yaml:"branch_max_len"`
-	BranchTrim   direction `yaml:"branch_trim"`
-	Ellipsis     string    `yaml:"ellipsis"`
-	HideClean    bool      `yaml:"hide_clean"`
+	BranchMaxLen      int       `yaml:"branch_max_len"`
+	BranchTrim        direction `yaml:"branch_trim"`
+	Ellipsis          string    `yaml:"ellipsis"`
+	HideClean         bool      `yaml:"hide_clean"`
+	SwapDivergence    bool      `yaml:"swap_divergence"`
 }
 
 // A Formater formats git status to a tmux style string.
@@ -240,13 +241,23 @@ func (f *Formater) divergence() string {
 		return ""
 	}
 
+    var s_behind string
+    var s_ahead string
 	s := f.Styles.Clear + f.Styles.Divergence
 	if f.st.BehindCount != 0 {
-		s += fmt.Sprintf("%s%d", f.Symbols.Behind, f.st.BehindCount)
+	    s_behind = fmt.Sprintf("%s%d", f.Symbols.Behind, f.st.BehindCount)
 	}
 
 	if f.st.AheadCount != 0 {
-		s += fmt.Sprintf("%s%d", f.Symbols.Ahead, f.st.AheadCount)
+		s_ahead = fmt.Sprintf("%s%d", f.Symbols.Ahead, f.st.AheadCount)
+	}
+
+	if !f.Options.SwapDivergence {
+	    // Behind first, ahead second
+        s += s_behind + s_ahead
+	} else {
+	    // Ahead first, behind second
+        s += s_ahead + s_behind
 	}
 
 	return s

--- a/tmux/formater.go
+++ b/tmux/formater.go
@@ -241,23 +241,23 @@ func (f *Formater) divergence() string {
 		return ""
 	}
 
-    var s_behind string
-    var s_ahead string
+    behind := ""
+    ahead := ""
 	s := f.Styles.Clear + f.Styles.Divergence
 	if f.st.BehindCount != 0 {
-	    s_behind = fmt.Sprintf("%s%d", f.Symbols.Behind, f.st.BehindCount)
+	    behind = fmt.Sprintf("%s%d", f.Symbols.Behind, f.st.BehindCount)
 	}
 
 	if f.st.AheadCount != 0 {
-		s_ahead = fmt.Sprintf("%s%d", f.Symbols.Ahead, f.st.AheadCount)
+		ahead = fmt.Sprintf("%s%d", f.Symbols.Ahead, f.st.AheadCount)
 	}
 
 	if !f.Options.SwapDivergence {
 	    // Behind first, ahead second
-        s += s_behind + s_ahead
+        s += behind + ahead
 	} else {
 	    // Ahead first, behind second
-        s += s_ahead + s_behind
+        s += ahead + behind
 	}
 
 	return s

--- a/tmux/formater_test.go
+++ b/tmux/formater_test.go
@@ -109,6 +109,7 @@ func TestDivergence(t *testing.T) {
 		name    string
 		styles  styles
 		symbols symbols
+		options options
 		st      *gitstatus.Status
 		want    string
 	}{
@@ -180,11 +181,71 @@ func TestDivergence(t *testing.T) {
 			},
 			want: "StyleClear" + "↑·128↓·41",
 		},
+		{
+			name: "swap divergence ahead only",
+			styles: styles{
+				Clear: "StyleClear",
+			},
+			symbols: symbols{
+				Ahead:  "↓·",
+				Behind: "↑·",
+			},
+			options: options{
+                SwapDivergence: true,
+			},
+			st: &gitstatus.Status{
+				Porcelain: gitstatus.Porcelain{
+					AheadCount:  4,
+					BehindCount: 0,
+				},
+			},
+			want: "StyleClear" + "↓·4",
+		},
+		{
+			name: "swap divergence behind only",
+			styles: styles{
+				Clear: "StyleClear",
+			},
+			symbols: symbols{
+				Ahead:  "↓·",
+				Behind: "↑·",
+			},
+			options: options{
+                SwapDivergence: true,
+			},
+			st: &gitstatus.Status{
+				Porcelain: gitstatus.Porcelain{
+					AheadCount:  0,
+					BehindCount: 12,
+				},
+			},
+			want: "StyleClear" + "↑·12",
+		},
+		{
+			name: "swap divergence both ways",
+			styles: styles{
+				Clear: "StyleClear",
+			},
+			symbols: symbols{
+				Ahead:  "↓·",
+				Behind: "↑·",
+			},
+			options: options{
+                SwapDivergence: true,
+			},
+			st: &gitstatus.Status{
+				Porcelain: gitstatus.Porcelain{
+					AheadCount:  41,
+					BehindCount: 128,
+				},
+			},
+			want: "StyleClear" + "↓·41↑·128",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			f := &Formater{
-				Config: Config{Styles: tt.styles, Symbols: tt.symbols},
+				Config: Config{Styles: tt.styles, Symbols: tt.symbols, Options: tt.options},
 				st:     tt.st,
 			}
 


### PR DESCRIPTION
## Purpose
Adding `swap_divergence` option to allow users to customize whether "upstream behind count" should be displayed first or "upstream ahead count".

Main motivation behind this was that I use `gitmux` in conjunction with `lazygit`. Lazygit's branch menu always shows `ahead` count first followed by `behind` count. I thought it'd be nice to be able to sync them up.

`swap_divergence: false`:
<img width="317" alt="image" src="https://user-images.githubusercontent.com/22674069/230660913-3f1d864a-eb0e-40de-b21d-827d2c59f122.png">

`swap_divergence: true`:
<img width="314" alt="image" src="https://user-images.githubusercontent.com/22674069/230661019-38989588-6f4e-4a6e-b271-5c338c191ed4.png">

## Approach
Added `swap_divergence` boolean flag for yaml file. Instead of appending to the returned string `s` right away, saving `ahead` and `behind` strings in separate vars then appending to original string `s` based on `swap_divergence` flag.

Thank you!
