### PR TITLE
feat: option to add space between behind & ahead upstream

### DIFF
--- a/.gitmux.yml
+++ b/.gitmux.yml
@@ -83,4 +83,4 @@ tmux:
         hide_clean: false
         # Swaps order of behind & ahead upstream counts - "↓·1↑·1" -> "↑·1↓·1"
         swap_divergence: false
-        space_between_divergence: false
+        divergence_space: false

--- a/.gitmux.yml
+++ b/.gitmux.yml
@@ -83,3 +83,4 @@ tmux:
         hide_clean: false
         # Swaps order of behind & ahead upstream counts - "↓·1↑·1" -> "↑·1↓·1"
         swap_divergence: false
+        space_between_divergence: false

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ tmux:
         ellipsis: …
         hide_clean: false
         swap_divergence: false
-        space_between_divergence: false
+        divergence_space: false
 ```
 
 First, save the default configuration to a new file:
@@ -272,7 +272,7 @@ This is the list of additional configuration `options`:
 | `ellipsis`                | Character to show branch name has been truncated           |        `…`         |
 | `hide_clean`              | Hides the clean flag entirely                              |      `false`       |
 | `swap_divergence`         | Swaps order of behind & ahead upstream counts              |      `false`       |
-| `space_between_divergence`| Add space between behind & ahead upstream counts           |      `false`       |
+| `divergence_space`        | Add space between behind & ahead upstream counts           |      `false`       |
 
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ tmux:
         ellipsis: …
         hide_clean: false
         swap_divergence: false
+        space_between_divergence: false
 ```
 
 First, save the default configuration to a new file:
@@ -264,13 +265,14 @@ layout: [branch, "|", flags, "|", stats]
 
 This is the list of additional configuration `options`:
 
-| Option           | Description                                                |      Default       |
-| :--------------- | :--------------------------------------------------------- | :----------------: |
-| `branch_max_len` | Maximum displayed length for local and remote branch names |   `0` (no limit)   |
-| `branch_trim`    | Trim left or right end of the branch (`right` or `left`)   | `right` (trailing) |
-| `ellipsis`       | Character to show branch name has been truncated           |        `…`         |
-| `hide_clean`     | Hides the clean flag entirely                              |      `false`       |
-| `swap_divergence`| Swaps order of behind & ahead upstream counts              |      `false`       |
+| Option                    | Description                                                |      Default       |
+| :------------------------ | :--------------------------------------------------------- | :----------------: |
+| `branch_max_len`          | Maximum displayed length for local and remote branch names |   `0` (no limit)   |
+| `branch_trim`             | Trim left or right end of the branch (`right` or `left`)   | `right` (trailing) |
+| `ellipsis`                | Character to show branch name has been truncated           |        `…`         |
+| `hide_clean`              | Hides the clean flag entirely                              |      `false`       |
+| `swap_divergence`         | Swaps order of behind & ahead upstream counts              |      `false`       |
+| `space_between_divergence`| Add space between behind & ahead upstream counts           |      `false`       |
 
 
 ## Troubleshooting

--- a/tmux/formater.go
+++ b/tmux/formater.go
@@ -85,12 +85,12 @@ func (d *direction) UnmarshalYAML(value *yaml.Node) error {
 }
 
 type options struct {
-	BranchMaxLen   int          `yaml:"branch_max_len"`
-	BranchTrim     direction    `yaml:"branch_trim"`
-	Ellipsis       string       `yaml:"ellipsis"`
-	HideClean      bool         `yaml:"hide_clean"`
-  SpaceBetweenDivergence bool `yaml:"space_between_divergence"`
-	SwapDivergence bool         `yaml:"swap_divergence"`
+	BranchMaxLen    int          `yaml:"branch_max_len"`
+	BranchTrim      direction    `yaml:"branch_trim"`
+	Ellipsis        string       `yaml:"ellipsis"`
+	HideClean       bool         `yaml:"hide_clean"`
+	DivergenceSpace bool         `yaml:"divergence_space"`
+	SwapDivergence  bool         `yaml:"swap_divergence"`
 }
 
 // A Formater formats git status to a tmux style string.
@@ -246,13 +246,13 @@ func (f *Formater) divergence() string {
 
 	behind := ""
 	ahead := ""
-  space := ""
+	space := ""
 
 	s := f.Styles.Clear + f.Styles.Divergence
 	if f.st.BehindCount != 0 {
-    if f.Options.SpaceBetweenDivergence {
-      space = " "
-    }
+	if f.Options.DivergenceSpace {
+		space = " "
+	}
 		behind = fmt.Sprintf("%s%d", f.Symbols.Behind, f.st.BehindCount)
 	}
 

--- a/tmux/formater.go
+++ b/tmux/formater.go
@@ -85,11 +85,12 @@ func (d *direction) UnmarshalYAML(value *yaml.Node) error {
 }
 
 type options struct {
-	BranchMaxLen   int       `yaml:"branch_max_len"`
-	BranchTrim     direction `yaml:"branch_trim"`
-	Ellipsis       string    `yaml:"ellipsis"`
-	HideClean      bool      `yaml:"hide_clean"`
-	SwapDivergence bool      `yaml:"swap_divergence"`
+	BranchMaxLen   int          `yaml:"branch_max_len"`
+	BranchTrim     direction    `yaml:"branch_trim"`
+	Ellipsis       string       `yaml:"ellipsis"`
+	HideClean      bool         `yaml:"hide_clean"`
+  SpaceBetweenDivergence bool `yaml:"space_between_divergence"`
+	SwapDivergence bool         `yaml:"swap_divergence"`
 }
 
 // A Formater formats git status to a tmux style string.
@@ -245,13 +246,18 @@ func (f *Formater) divergence() string {
 
 	behind := ""
 	ahead := ""
+  space := ""
+
 	s := f.Styles.Clear + f.Styles.Divergence
 	if f.st.BehindCount != 0 {
+    if f.Options.SpaceBetweenDivergence {
+      space = " "
+    }
 		behind = fmt.Sprintf("%s%d", f.Symbols.Behind, f.st.BehindCount)
 	}
 
 	if f.st.AheadCount != 0 {
-		ahead = fmt.Sprintf("%s%d", f.Symbols.Ahead, f.st.AheadCount)
+		ahead = fmt.Sprintf("%s%s%d", space, f.Symbols.Ahead, f.st.AheadCount)
 	}
 
 	if !f.Options.SwapDivergence {

--- a/tmux/formater_test.go
+++ b/tmux/formater_test.go
@@ -182,6 +182,88 @@ func TestDivergence(t *testing.T) {
 			want: "StyleClear" + "↑·128↓·41",
 		},
 		{
+			name: "space between behind only",
+			styles: styles{
+				Clear: "StyleClear",
+			},
+			symbols: symbols{
+				Ahead:  "↓·",
+				Behind: "↑·",
+			},
+			options: options{
+				DivergenceSpace: true,
+			},
+			st: &gitstatus.Status{
+				Porcelain: gitstatus.Porcelain{
+					AheadCount:  0,
+					BehindCount: 12,
+				},
+			},
+			want: "StyleClear" + "↑·12",
+		},
+		{
+			name: "space between diverged both way",
+			styles: styles{
+				Clear: "StyleClear",
+			},
+			symbols: symbols{
+				Ahead:  "↓·",
+				Behind: "↑·",
+			},
+			options: options{
+				DivergenceSpace: true,
+				SwapDivergence: false
+			},
+			st: &gitstatus.Status{
+				Porcelain: gitstatus.Porcelain{
+				AheadCount:  41,
+				BehindCount: 128,
+				},
+			},
+			want: "StyleClear" + "↑·128 ↓·41",
+		},
+		{
+			name: "space between swap divergence both ways",
+			styles: styles{
+				Clear: "StyleClear",
+			},
+			symbols: symbols{
+				Ahead:  "↓·",
+				Behind: "↑·",
+			},
+			options: options{
+				DivergenceSpace: true,
+				SwapDivergence: true,
+			},
+			st: &gitstatus.Status{
+				Porcelain: gitstatus.Porcelain{
+				AheadCount:  41,
+				BehindCount: 128,
+				},
+			},
+			want: "StyleClear" + "↓·41 ↑·128",
+		},
+		{
+			name: "no space between diverged both way",
+			styles: styles{
+				Clear: "StyleClear",
+			},
+			symbols: symbols{
+				Ahead:  "↓·",
+				Behind: "↑·",
+			},
+			options: options{
+				DivergenceSpace: false,
+			},
+			st: &gitstatus.Status{
+				Porcelain: gitstatus.Porcelain{
+				AheadCount:  41,
+				BehindCount: 128,
+				},
+			},
+			want: "StyleClear" + "↑·128↓·41",
+		},
+		{
 			name: "swap divergence ahead only",
 			styles: styles{
 				Clear: "StyleClear",


### PR DESCRIPTION
## Purpose
Adding a space between behind & ahead upstream is currently not possible

## Approach
Adding an option to add a single space


Before 
<img width="398" alt="Screenshot 2024-04-15 at 15 46 38" src="https://github.com/arl/gitmux/assets/3860298/1280d8e4-5323-465c-a218-ffc674e49c2c">

After
<img width="341" alt="Screenshot 2024-04-15 at 15 47 17" src="https://github.com/arl/gitmux/assets/3860298/1313ae9e-662f-4c1b-803e-fba78fe2f00b">

