### PR TITLE
feat: trim branch from center

### DIFF
--- a/.gitmux.yml
+++ b/.gitmux.yml
@@ -75,7 +75,7 @@ tmux:
     options:
         # Maximum displayed length for local and remote branch names.
         branch_max_len: 0
-        # Trim left or right end of the branch (`right` or `left`).
+        # Trim left, right or from the center of the branch (`right`, `left` or `center`).
         branch_trim: right
         # Character indicating whether and where a branch was truncated.
         ellipsis: …

--- a/README.md
+++ b/README.md
@@ -264,14 +264,13 @@ layout: [branch, "|", flags, "|", stats]
 
 This is the list of additional configuration `options`:
 
-| Option           | Description                                                |      Default       |
-| :--------------- | :--------------------------------------------------------- | :----------------: |
-| `branch_max_len` | Maximum displayed length for local and remote branch names |   `0` (no limit)   |
-| `branch_trim`    | Trim left or right end of the branch (`right` or `left`)   | `right` (trailing) |
-| `ellipsis`       | Character to show branch name has been truncated           |        `…`         |
-| `hide_clean`     | Hides the clean flag entirely                              |      `false`       |
-| `swap_divergence`| Swaps order of behind & ahead upstream counts              |      `false`       |
-
+| Option            | Description                                                                     |      Default       |
+| :---------------- | :------------------------------------------------------------------------------ | :----------------: |
+| `branch_max_len`  | Maximum displayed length for local and remote branch names                      |   `0` (no limit)   |
+| `branch_trim`     | Trim left, right or from the center of the branch (`right`, `left` or `center`) | `right` (trailing) |
+| `ellipsis`        | Character to show branch name has been truncated                                |        `…`         |
+| `hide_clean`      | Hides the clean flag entirely                                                   |      `false`       |
+| `swap_divergence` | Swaps order of behind & ahead upstream counts                                   |      `false`       |
 
 ## Troubleshooting
 

--- a/tmux/formater.go
+++ b/tmux/formater.go
@@ -62,8 +62,9 @@ type styles struct {
 }
 
 const (
-	dirLeft  direction = "left"
-	dirRight direction = "right"
+	dirLeft   direction = "left"
+	dirRight  direction = "right"
+	dirCenter direction = "center"
 )
 
 type direction string
@@ -78,6 +79,8 @@ func (d *direction) UnmarshalYAML(value *yaml.Node) error {
 		*d = dirLeft
 	case dirRight:
 		*d = dirRight
+	case dirCenter:
+		*d = dirCenter
 	default:
 		return fmt.Errorf("'direction': unexpected value %v", s)
 	}
@@ -99,8 +102,8 @@ type Formater struct {
 }
 
 // truncate returns s, truncated so that it is no more than max runes long.
-// Depending on the provided direction, truncation is performed right or left.
-// If s is returned truncated, the truncated part is replaced with the
+// Depending on the provided direction, truncation is performed right, left or
+// center. If s is returned truncated, the truncated part is replaced with the
 // 'ellipsis' string.
 //
 // If max is zero, negative or greater than the number of runes in s, truncate
@@ -129,6 +132,16 @@ func truncate(s, ellipsis string, max int, dir direction) string {
 	case dirLeft:
 		runes = runes[len(runes)+len(ell)-max:]
 		runes = append(ell, runes...)
+	case dirCenter:
+		// We want to keep the same number of runes on both sides of the ellipsis. If the
+		// number of runes on each side is odd, we add one more rune to the right side.
+		llen := (max - len(ell)) / 2
+		rlen := max - len(ell) - llen
+
+		right := runes[len(runes)-rlen:]
+
+		runes = append(runes[:llen], ell...)
+		runes = append(runes, right...)
 	}
 	return string(runes)
 }

--- a/tmux/formater_test.go
+++ b/tmux/formater_test.go
@@ -412,6 +412,78 @@ func Test_truncate(t *testing.T) {
 			dir:      dirLeft,
 			want:     "super-long-branch",
 		},
+
+		/* trim center */
+		{
+			s:        "br",
+			ellipsis: "...",
+			max:      1,
+			dir:      dirCenter,
+			want:     "r",
+		},
+		{
+			s:        "br",
+			ellipsis: "",
+			max:      1,
+			dir:      dirCenter,
+			want:     "r",
+		},
+		{
+			s:        "br",
+			ellipsis: "...",
+			max:      3,
+			dir:      dirCenter,
+			want:     "br",
+		},
+		{
+			s:        "super-long-branch",
+			ellipsis: "...",
+			max:      3,
+			dir:      dirCenter,
+			want:     "...",
+		},
+		{
+			s:        "super-long-branch",
+			ellipsis: "...",
+			max:      15,
+			dir:      dirCenter,
+			want:     "super-...branch",
+		},
+		{
+			s:        "super-long-branch",
+			ellipsis: "...",
+			max:      17,
+			dir:      dirCenter,
+			want:     "super-long-branch",
+		},
+		{
+			s:        "长長的-树樹枝",
+			ellipsis: "...",
+			max:      6,
+			dir:      dirCenter,
+			want:     "长...樹枝",
+		},
+		{
+			s:        "super-long-branch",
+			ellipsis: "...",
+			max:      32,
+			dir:      dirCenter,
+			want:     "super-long-branch",
+		},
+		{
+			s:        "super-long-branch",
+			ellipsis: "...",
+			max:      0,
+			dir:      dirCenter,
+			want:     "super-long-branch",
+		},
+		{
+			s:        "super-long-branch",
+			ellipsis: "...",
+			max:      -1,
+			dir:      dirCenter,
+			want:     "super-long-branch",
+		},
 	}
 	for _, tt := range tests {
 		t.Run("", func(t *testing.T) {


### PR DESCRIPTION
## Purpose

I tend to follow a naming convention for branches, and when I work on big features that are split into different PRs, the beginning and the end of the branches contains the most significant context, i.e: `feat/<ticket_id>/<feature-name>-<feature-portion>`. In these cases I find useful seeing the beginning of the branch, and as I already know which feature I'm working on, I find more value by seeing the last part, as it usually refers to a smaller portion of the whole feature.

Hopefully others also finds this useful.

## Approach

Trim the branch from the inside out, so that

`feat/COR-1032/supplier-billing-profile-invoice-upload`

becomes

`feat/COR-1032/…invoice-upload`