### PR TITLE
Fix/ci and brew tap

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -7,8 +7,8 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: "1.20.x"
       - name: Run tests

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,6 +39,7 @@ brews:
     license: "MIT"
     url_template: "https://github.com/arl/gitmux/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
     commit_msg_template: "Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
+    directory: Formula
     skip_upload: false
     repository:
       owner: arl


### PR DESCRIPTION
Fix homebrew tap after bump from goreleaser v1 to v2