### PR TITLE
Drop "tap" langauge for homebrew installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,10 @@ Works with all reasonably recent [tmux](https://github.com/tmux/tmux) versions (
 [Download the latest](https://github.com/arl/gitmux/releases/latest) binary for your platform/architecture and uncompress it.
 
 
-### Homebrew tap (macOS and linux) (amd64 and arm64)
+### Homebrew (macOS and linux) (amd64 and arm64)
 
 Install the latest version with:
 
-    brew tap arl/arl
     brew install gitmux
 
 ### AUR


### PR DESCRIPTION
## Purpose
For #78

## Approach
Removes all `tap` related language in the homebrew instructions on the README since gitmux is now on core! 🎉