### PR TITLE
go.mod: revert use of gitmux as module name

### DIFF
--- a/config.go
+++ b/config.go
@@ -6,7 +6,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
-	"gitmux/tmux"
+	"github.com/arl/gitmux/tmux"
 )
 
 // Config configures output formatting.

--- a/gitmux.go
+++ b/gitmux.go
@@ -10,8 +10,8 @@ import (
 	"github.com/arl/gitstatus"
 	"gopkg.in/yaml.v3"
 
-	"gitmux/json"
-	"gitmux/tmux"
+	"github.com/arl/gitmux/json"
+	"github.com/arl/gitmux/tmux"
 )
 
 var version = "<<development version>>"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module gitmux
+module github.com/arl/gitmux
 
 go 1.24
 


### PR DESCRIPTION
Fix #127
